### PR TITLE
pal: Fix crash caused by getpwuid() returning NULL

### DIFF
--- a/src/pal/src/pal_enclave.c
+++ b/src/pal/src/pal_enclave.c
@@ -66,7 +66,10 @@ int pal_init_enclave(const char *instance_dir) {
      *         if there is no token, then create a new one.
      */
     /* try to get the token saved in $HOME */
-    const char *home_dir = getpwuid(getuid())->pw_dir;
+    const char *home_dir = NULL;
+    struct passwd *pw = getpwuid(getuid());
+    if (pw != NULL)
+        home_dir = pw->pw_dir;
 
     if (home_dir != NULL &&
             (strlen(home_dir) + strlen("/") + sizeof(TOKEN_FILENAME) + 1) <= MAX_PATH) {


### PR DESCRIPTION
On lightweight Linux distribution, like alpine, getpwuid()
returns NULL, and errno is ENOENT, this patch fix crash
caused by this situation.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>