### PR TITLE
Enable TFLite and OpenVINO test for CI and add CI image build action

### DIFF
--- a/.github/workflows/build_and_push_ci_image.yml
+++ b/.github/workflows/build_and_push_ci_image.yml
@@ -1,0 +1,98 @@
+name: Build Image for CI (Manual Trigger)
+# For some demos which need a lot of dependencies, building and installing depencies
+# during every test consumes much time. Thus, build images specific for these demos.
+# Now only grpc and openvino need its own test image. The images are stored in
+# "occlumbackup/occlum" dockerhub repo.
+
+
+# This is a manual trigger.
+on:
+  workflow_dispatch:
+    inputs:
+      demo_name:
+        description: 'demo image name (must choose from <grpc, openvino>)'
+        required: true
+        default: 'grpc'
+      tag:
+        description: 'image tag'
+        required: true
+        default: 'latest'
+
+
+jobs:
+  Build_grpc_image:
+    runs-on: ubuntu-18.04
+    if: github.event.inputs.demo_name == 'grpc'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get occlum version
+      run: echo ::set-env name=OCCLUM_VERSION::$(grep "Version =" src/pal/include/occlum_version.h |  awk '{print $4}')
+
+    # Because "Build and push" step `context` field can't be subdir,
+    # we need to copy files needed by dockerfile to root dir of the project
+    - name: Copy context for docker build
+      run: |
+        cp -r tools/docker .
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./tools/docker/ci/Dockerfile.grpc
+        platforms: linux/amd64
+        build-args: OCCLUM_VERSION=${{ env.OCCLUM_VERSION }}
+        push: true
+        tags: occlumbackup/occlum:${{ github.event.inputs.tag }}-ubuntu18.04-grpc
+
+
+  Build_openvino_image:
+    runs-on: ubuntu-18.04
+    if: github.event.inputs.demo_name == 'openvino'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get occlum version
+      run: echo ::set-env name=OCCLUM_VERSION::$(grep "Version =" src/pal/include/occlum_version.h |  awk '{print $4}')
+
+    # Because "Build and push" step `context` field can't be subdir,
+    # we need to copy files needed by dockerfile to root dir of the project
+    - name: Copy context for docker build
+      run: |
+        cp -r tools/docker .
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./tools/docker/ci/Dockerfile.openvino
+        platforms: linux/amd64
+        build-args: OCCLUM_VERSION=${{ env.OCCLUM_VERSION }}
+        push: true
+        tags: occlumbackup/occlum:${{ github.event.inputs.tag }}-ubuntu18.04-openvino

--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -213,43 +213,6 @@ jobs:
         docker exec https_test bash -c "curl -k https://127.0.0.1:8443"
 
 
-  Grpc_test:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-
-    - name: Get occlum version
-      run: echo ::set-env name=OCCLUM_VERSION::$(grep "Version =" src/pal/include/occlum_version.h |  awk '{print $4}')
-
-    - name: Create container
-      run: docker run -itd --name=grpc_test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
-
-    - name: Build dependencies
-      run: docker exec grpc_test bash -c "cd /root/occlum; make submodule"
-
-    - name: Make install
-      run: docker exec grpc_test bash -c "cd /root/occlum; OCCLUM_RELEASE_BUILD=y make install"
-
-    - name: Install openssl
-      run: docker exec grpc_test bash -c "cd /root/occlum/demos/grpc && ./download_and_install_openssl.sh"
-
-    - name: Build grpc dependencies
-      run: docker exec grpc_test bash -c "cd /root/occlum/demos/grpc && ./download_and_install_grpc.sh"
-
-    - name: Prepare grpc sample project
-      run: docker exec grpc_test bash -c "cd /root/occlum/demos/grpc && ./prepare_client_server.sh"
-
-    - name: Run grpc server
-      run: docker exec grpc_test bash -c "cd /root/occlum/demos/grpc && SGX_MODE=SIM ./run_server_on_occlum.sh" &
-
-    - name: Run grpc client
-      run: |
-        sleep ${{ env.nap_time }};
-        docker exec grpc_test bash -c "cd /root/occlum/demos/grpc && SGX_MODE=SIM ./run_client_on_occlum.sh"
-
-
   Local_attestation_test:
     runs-on: ubuntu-18.04
     steps:
@@ -332,3 +295,81 @@ jobs:
     # TODO: Remove " || true " because in simulation mode, process exits brutely and can cause segmentation fault in some cases.
     - name: Run xgboost cluster test
       run: docker exec xgboost_test bash -c "cd /root/occlum/demos/xgboost && SGX_MODE=SIM make test-local-cluster" || true
+
+
+  Tensorflow_lite_test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Get occlum version
+      run: echo ::set-env name=OCCLUM_VERSION::$(grep "Version =" src/pal/include/occlum_version.h |  awk '{print $4}')
+
+    - name: Create container
+      run: docker run -itd --name=tflite_test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
+
+    - name: Build dependencies
+      run: docker exec tflite_test bash -c "cd /root/occlum; make submodule"
+
+    - name: Make install
+      run: docker exec tflite_test bash -c "cd /root/occlum; OCCLUM_RELEASE_BUILD=y make install"
+
+    - name: Build Tensorflow-lite dependencies
+      run: docker exec tflite_test bash -c "cd /root/occlum/demos/tensorflow_lite && ./download_and_build_tflite.sh"
+
+    - name: Run Tensorflow-lite demo
+      run: docker exec tflite_test bash -c "cd /root/occlum/demos/tensorflow_lite && SGX_MODE=SIM ./run_tflite_in_occlum.sh demo"
+
+    - name: Run Tensorflow-lite benchmark
+      run: docker exec tflite_test bash -c "cd /root/occlum/demos/tensorflow_lite && SGX_MODE=SIM ./run_tflite_in_occlum.sh benchmark"
+
+
+# Below tests needs test image to run faster
+  Grpc_test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Create container
+      run: docker run -itd --name=grpc_test -v $GITHUB_WORKSPACE:/root/occlum occlumbackup/occlum:latest-ubuntu18.04-grpc
+
+    - name: Build dependencies
+      run: docker exec grpc_test bash -c "cd /root/occlum; make submodule"
+
+    - name: Make install
+      run: docker exec grpc_test bash -c "cd /root/occlum; OCCLUM_RELEASE_BUILD=y make install"
+
+    - name: Prepare grpc sample project
+      run: docker exec grpc_test bash -c "cd /root/demos/grpc && ./prepare_client_server.sh"
+
+    - name: Run grpc server
+      run: docker exec grpc_test bash -c "cd /root/demos/grpc && SGX_MODE=SIM ./run_server_on_occlum.sh" &
+
+    - name: Run grpc client
+      run: |
+        sleep ${{ env.nap_time }};
+        docker exec grpc_test bash -c "cd /root/demos/grpc && SGX_MODE=SIM ./run_client_on_occlum.sh"
+
+
+  Openvino_test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Create container
+      run: docker run -itd --name=openvino_test -v $GITHUB_WORKSPACE:/root/occlum occlumbackup/occlum:latest-ubuntu18.04-openvino
+
+    - name: Build dependencies
+      run: docker exec openvino_test bash -c "cd /root/occlum; make submodule"
+
+    - name: Make install
+      run: docker exec openvino_test bash -c "cd /root/occlum; OCCLUM_RELEASE_BUILD=y make install"
+
+    - name: Run openVINO benchmark
+      run: docker exec openvino_test bash -c "cd /root/demos/openvino && SGX_MODE=SIM ./run_benchmark_on_occlum.sh"

--- a/tools/docker/ci/Dockerfile.grpc
+++ b/tools/docker/ci/Dockerfile.grpc
@@ -1,0 +1,14 @@
+ARG OCCLUM_VERSION
+FROM occlum/occlum:$OCCLUM_VERSION-ubuntu18.04 as base
+LABEL maintainer="Chunyang Hui <sanqian.hcy@antgroup.com>"
+
+WORKDIR /root
+RUN git clone https://github.com/occlum/occlum.git && \
+    cp -r occlum/demos /root/demos && \
+    rm -rf /root/occlum
+
+WORKDIR /root/demos/grpc
+RUN bash -x download_and_install_openssl.sh && \
+    bash -x download_and_install_grpc.sh
+
+WORKDIR /root

--- a/tools/docker/ci/Dockerfile.openvino
+++ b/tools/docker/ci/Dockerfile.openvino
@@ -1,0 +1,15 @@
+ARG OCCLUM_VERSION
+FROM occlum/occlum:$OCCLUM_VERSION-ubuntu18.04 as base
+LABEL maintainer="Chunyang Hui <sanqian.hcy@antgroup.com>"
+
+WORKDIR /root
+RUN git clone https://github.com/occlum/occlum.git && \
+    cp -r occlum/demos /root/demos && \
+    rm -rf /root/occlum
+
+WORKDIR /root/demos/openvino
+RUN bash -x install_cmake.sh && \
+    bash -x download_and_build_openvino.sh && \
+    bash -x download_openvino_model.sh
+
+WORKDIR /root


### PR DESCRIPTION
This commit mainly does two things:
1.  Add a manual trigger action to build images for demo CI. Once it merged, it will look like below and only the project owner can trigger building new image for demo CI.
![截屏2020-09-23下午2 52 08](https://user-images.githubusercontent.com/13930406/93977398-fd0e5a80-fdac-11ea-8e82-715322f8b111.png)


2. Add openvino and tflite test