### PR TITLE
Fix copy softlink for make install and deb installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/libsgx_uae_service_sim.so: /opt/intel/sgxsdk
 	@cp /opt/intel/sgxsdk/lib64/{libsgx_ptrace.so,libsgx_uae_service_sim.so} $(OCCLUM_PREFIX)/sgxsdk-tools/lib64
 	@mkdir -p $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/gdb-sgx-plugin
 	@cd /opt/intel/sgxsdk/lib64/gdb-sgx-plugin/ && cp $$(ls -A | grep -v __pycache__) $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/gdb-sgx-plugin
-	@cd /opt/intel/sgxsdk && cp --parents {bin/sgx-gdb,bin/x64/sgx_sign,sdk_libs/libsgx_uae_service_sim.so} $(OCCLUM_PREFIX)/sgxsdk-tools/
+	@cd /opt/intel/sgxsdk && cp -a --parents {bin/sgx-gdb,bin/x64/sgx_sign,sdk_libs/libsgx_uae_service_sim.so} $(OCCLUM_PREFIX)/sgxsdk-tools/
 	@# Delete SGX_LIBRARY_PATH env in sgx-gdb which are defined in etc/environment
 	@sed -i '/^SGX_LIBRARY_PATH=/d' $(OCCLUM_PREFIX)/sgxsdk-tools/bin/sgx-gdb
 	@cp etc/environment $(OCCLUM_PREFIX)/sgxsdk-tools/

--- a/tools/installer/deb/occlum/rules
+++ b/tools/installer/deb/occlum/rules
@@ -29,11 +29,11 @@ override_dh_install:
 
 	# generate occlum-runtime
 	mkdir -p $(occlum-runtime-buildroot)
-	cd $(buildroot) && cat $(deb_build_dir)/occlum-$(VERSION)/debian/occlum-runtime-filelist | xargs -I files bash -c "cp --parents --target-directory=$(occlum-runtime-buildroot) files"
+	cd $(buildroot) && cat $(deb_build_dir)/occlum-$(VERSION)/debian/occlum-runtime-filelist | xargs -I files bash -c "cp -a --parents --target-directory=$(occlum-runtime-buildroot) files"
 
 	# generate occlum-pal
 	mkdir -p $(occlum-pal-buildroot)
-	cd $(buildroot) && cat $(deb_build_dir)/occlum-$(VERSION)/debian/occlum-pal-filelist | xargs -I files bash -c "cp --parents --target-directory=$(occlum-pal-buildroot) files"
+	cd $(buildroot) && cat $(deb_build_dir)/occlum-$(VERSION)/debian/occlum-pal-filelist | xargs -I files bash -c "cp -a --parents --target-directory=$(occlum-pal-buildroot) files"
 
 	# generate occlum-sgx-tools
 	mkdir -p $(occlum-sgx-tools-buildroot)/opt/occlum
@@ -41,7 +41,7 @@ override_dh_install:
 
 	# generate occlum package
 	mkdir -p $(occlum-buildroot)
-	cd $(buildroot) && cat $(deb_build_dir)/occlum-$(VERSION)/debian/occlum-filelist | xargs -I files bash -c "cp --parents --target-directory=$(occlum-buildroot) files"
+	cd $(buildroot) && cat $(deb_build_dir)/occlum-$(VERSION)/debian/occlum-filelist | xargs -I files bash -c "cp -a --parents --target-directory=$(occlum-buildroot) files"
 
 clean:
 	dh_clean


### PR DESCRIPTION
  man cp：
> -a, --archive
same as -dR --preserve=all
-d
same as --no-dereference --preserve=links
-P, --no-dereference
never follow symbolic links in SOURCE
--preserve[=ATTR_LIST]
preserve the specified attributes (default: mode,ownership,timestamps), if possible additional attributes: context, links, xattr, all
