### PR TITLE
Add the gRPC-golang benchmark

### DIFF
--- a/demos/golang/grpc_benchmark/0001-Add-the-remote-benchmark-feature.patch
+++ b/demos/golang/grpc_benchmark/0001-Add-the-remote-benchmark-feature.patch
@@ -1,0 +1,34 @@
+From 38c366141d60c873234e8d14ed0876d79770e3b0 Mon Sep 17 00:00:00 2001
+From: yuanwu <yuan.wu@intel.com>
+Date: Wed, 16 Sep 2020 16:18:11 +0000
+Subject: [PATCH] Add the remote benchmark feature
+
+Signed-off-by: yuanwu <yuan.wu@intel.com>
+---
+ benchmark/client/main.go | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/benchmark/client/main.go b/benchmark/client/main.go
+index f750c5c3..50694a6c 100644
+--- a/benchmark/client/main.go
++++ b/benchmark/client/main.go
+@@ -57,6 +57,7 @@ import (
+ )
+ 
+ var (
++	ip        = flag.String("ip", "localhost", "ip to connect to.")
+ 	port      = flag.String("port", "50051", "Localhost port to connect to.")
+ 	numRPC    = flag.Int("r", 1, "The number of concurrent RPCs on each connection.")
+ 	numConn   = flag.Int("c", 1, "The number of parallel connections.")
+@@ -133,7 +134,7 @@ func main() {
+ func buildConnections(ctx context.Context) []*grpc.ClientConn {
+ 	ccs := make([]*grpc.ClientConn, *numConn)
+ 	for i := range ccs {
+-		ccs[i] = benchmark.NewClientConnWithContext(ctx, "localhost:"+*port, grpc.WithInsecure(), grpc.WithBlock())
++		ccs[i] = benchmark.NewClientConnWithContext(ctx, *ip +":"+*port, grpc.WithInsecure(), grpc.WithBlock())
+ 	}
+ 	return ccs
+ }
+-- 
+2.17.1
+

--- a/demos/golang/grpc_benchmark/README.md
+++ b/demos/golang/grpc_benchmark/README.md
@@ -1,0 +1,24 @@
+1. Download and build the grpc benchmark
+$./download_and_build_grpc_benchmark.sh
+
+2. Run the host benchmark
+$./run_host_bench.sh
+
+3. Run the occlum benchmark
+$./run_occlum_bench.sh
+
+4. Run the server and client in different machine. 
+   Step1: Run the server application fistly
+	$./run_host_server.sh
+	or
+	$./run_occlum_server.sh
+	Note: If you are running occlum server, please wait for several minutes.
+	Because the server app of occlum need more time to execute.
+   Step2: Run the client app in another machine.
+	Modify line 10 of run_host_client.sh ip="localhost" -> ip="your server ip"
+	$./run_host_client.sh
+
+Note: If you run the server application in a docker, you need to public the container's port to host.
+For example:
+$./docker run -p 50051:50051 -it IMAGE_ID
+

--- a/demos/golang/grpc_benchmark/download_and_build_grpc_benchmark.sh
+++ b/demos/golang/grpc_benchmark/download_and_build_grpc_benchmark.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+export GOPATH=$PWD
+out_dir=$PWD/bin
+occlum-go get -u google.golang.org/grpc
+cd src/google.golang.org/grpc/
+git reset --hard 0f7e218c2cf49c7b0ca8247711b0daed2a07e79a
+git am ../../../0001-Add-the-remote-benchmark-feature.patch
+rm -rf ${out_dir}
+mkdir ${out_dir}
+occlum-go build -o ${out_dir}/server $GOPATH/src/google.golang.org/grpc/benchmark/server/main.go && occlum-go build -o ${out_dir}/client $GOPATH/src/google.golang.org/grpc/benchmark/client/main.go

--- a/demos/golang/grpc_benchmark/run_host_bench.sh
+++ b/demos/golang/grpc_benchmark/run_host_bench.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+rpcs=(1)
+conns=(1)
+warmup=10
+dur=10
+reqs=(1)
+resps=(1)
+rpc_types=(unary)
+
+export GOPATH=$PWD
+out_dir=$PWD/bin
+# idx[0] = idx value for rpcs
+# idx[1] = idx value for conns
+# idx[2] = idx value for reqs
+# idx[3] = idx value for resps
+# idx[4] = idx value for rpc_types
+idx=(0 0 0 0 0)
+idx_max=(1 1 1 1 1)
+
+inc()
+{
+  for i in $(seq $((${#idx[@]}-1)) -1 0); do
+    idx[${i}]=$((${idx[${i}]}+1))
+    if [ ${idx[${i}]} == ${idx_max[${i}]} ]; then
+      idx[${i}]=0
+    else
+      break
+    fi
+  done
+  local fin
+  fin=1
+  # Check to see if we have looped back to the beginning.
+  for v in ${idx[@]}; do
+    if [ ${v} != 0 ]; then
+      fin=0
+      break
+    fi
+  done
+  if [ ${fin} == 1 ]; then
+    #rm -Rf ${out_dir}
+    clean_and_die 0
+  fi
+}
+
+clean_and_die() {
+  #rm -Rf ${out_dir}
+  exit $1
+}
+
+run(){
+  local nr
+  nr=${rpcs[${idx[0]}]}
+  local nc
+  nc=${conns[${idx[1]}]}
+  req_sz=${reqs[${idx[2]}]}
+  resp_sz=${resps[${idx[3]}]}
+  r_type=${rpc_types[${idx[4]}]}
+  # Following runs one benchmark
+  base_port=50051
+  delta=0
+  test_name="r_"${nr}"_c_"${nc}"_req_"${req_sz}"_resp_"${resp_sz}"_"${r_type}"_"$(date +%s)
+  echo "================================================================================"
+  echo ${test_name}
+  while :
+  do
+    port=$((${base_port}+${delta}))
+
+    # Launch the server in background
+    ${out_dir}/server --port=${port} --test_name="Server_"${test_name}&
+    server_pid=$(echo $!)
+
+    # Launch the client
+    ${out_dir}/client --port=${port} --d=${dur} --w=${warmup} --r=${nr} --c=${nc} --req=${req_sz} --resp=${resp_sz} --rpc_type=${r_type}  --test_name="client_"${test_name}
+    client_status=$(echo $?)
+
+    kill -INT ${server_pid}
+    wait ${server_pid}
+
+    if [ ${client_status} == 0 ]; then
+      break
+    fi
+
+    delta=$((${delta}+1))
+    if [ ${delta} == 10 ]; then
+      echo "Continuous 10 failed runs. Exiting now."
+      #rm -Rf ${out_dir}
+      clean_and_die 1
+    fi
+  done
+
+}
+
+set_param(){
+  local argname=$1
+  shift
+  local idx=$1
+  shift
+  if [ $# -eq 0 ]; then
+    echo "${argname} not specified"
+    exit 1
+  fi
+  PARAM=($(echo $1 | sed 's/,/ /g'))
+  if [ ${idx} -lt 0 ]; then
+    return
+  fi
+  idx_max[${idx}]=${#PARAM[@]}
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r)
+      shift
+      set_param "number of rpcs" 0 $1
+      rpcs=(${PARAM[@]})
+      shift
+      ;;
+    -c)
+      shift
+      set_param "number of connections" 1 $1
+      conns=(${PARAM[@]})
+      shift
+      ;;
+    -w)
+      shift
+      set_param "warm-up period" -1 $1
+      warmup=${PARAM}
+      shift
+      ;;
+    -d)
+      shift
+      set_param "duration" -1 $1
+      dur=${PARAM}
+      shift
+      ;;
+    -req)
+      shift
+      set_param "request size" 2 $1
+      reqs=(${PARAM[@]})
+      shift
+      ;;
+    -resp)
+      shift
+      set_param "response size" 3 $1
+      resps=(${PARAM[@]})
+      shift
+      ;;
+    -rpc_type)
+      shift
+      set_param "rpc type" 4 $1
+      rpc_types=(${PARAM[@]})
+      shift
+      ;;
+    -h|--help)
+      echo "Following are valid options:"
+      echo
+      echo "-h, --help        show brief help"
+      echo "-w                warm-up duration in seconds, default value is 10"
+      echo "-d                benchmark duration in seconds, default value is 60"
+      echo ""
+      echo "Each of the following can have multiple comma separated values."
+      echo ""
+      echo "-r                number of RPCs, default value is 1"
+      echo "-c                number of Connections, default value is 1"
+      echo "-req              req size in bytes, default value is 1"
+      echo "-resp             resp size in bytes, default value is 1"
+      echo "-rpc_type         valid values are unary|streaming, default is unary"
+      exit 0
+      ;;
+    *)
+      echo "Incorrect option $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Build server and client
+if [ $? != 0 ]; then
+  clean_and_die 1
+fi
+
+
+while :
+do
+  run
+  inc
+done

--- a/demos/golang/grpc_benchmark/run_host_client.sh
+++ b/demos/golang/grpc_benchmark/run_host_client.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+rpcs=(1)
+conns=(1)
+warmup=10
+dur=10
+reqs=(1)
+resps=(1)
+rpc_types=(unary)
+ip="localhost"
+export GOPATH=$PWD
+out_dir=$PWD/bin
+# idx[0] = idx value for rpcs
+# idx[1] = idx value for conns
+# idx[2] = idx value for reqs
+# idx[3] = idx value for resps
+# idx[4] = idx value for rpc_types
+idx=(0 0 0 0 0)
+idx_max=(1 1 1 1 1)
+
+inc()
+{
+  for i in $(seq $((${#idx[@]}-1)) -1 0); do
+    idx[${i}]=$((${idx[${i}]}+1))
+    if [ ${idx[${i}]} == ${idx_max[${i}]} ]; then
+      idx[${i}]=0
+    else
+      break
+    fi
+  done
+  local fin
+  fin=1
+  # Check to see if we have looped back to the beginning.
+  for v in ${idx[@]}; do
+    if [ ${v} != 0 ]; then
+      fin=0
+      break
+    fi
+  done
+  if [ ${fin} == 1 ]; then
+    clean_and_die 0
+  fi
+}
+
+clean_and_die() {
+  exit $1
+}
+
+run(){
+  local nr
+  nr=${rpcs[${idx[0]}]}
+  local nc
+  nc=${conns[${idx[1]}]}
+  req_sz=${reqs[${idx[2]}]}
+  resp_sz=${resps[${idx[3]}]}
+  r_type=${rpc_types[${idx[4]}]}
+  # Following runs one benchmark
+  port=50051
+  delta=0
+  test_name="r_"${nr}"_c_"${nc}"_req_"${req_sz}"_resp_"${resp_sz}"_"${r_type}"_"$(date +%s)
+  echo "================================================================================"
+  echo ${test_name}
+  while :
+  do
+
+
+    # Launch the client
+    ${out_dir}/client --ip=${ip} --port=${port} --d=${dur} --w=${warmup} --r=${nr} --c=${nc} --req=${req_sz} --resp=${resp_sz} --rpc_type=${r_type}  --test_name="client_"${test_name}
+    client_status=$(echo $?)
+
+
+    if [ ${client_status} == 0 ]; then
+      break
+    fi
+
+    delta=$((${delta}+1))
+    if [ ${delta} == 10 ]; then
+      echo "Continuous 10 failed runs. Exiting now."
+      clean_and_die 1
+    fi
+  done
+
+}
+
+set_param(){
+  local argname=$1
+  shift
+  local idx=$1
+  shift
+  if [ $# -eq 0 ]; then
+    echo "${argname} not specified"
+    exit 1
+  fi
+  PARAM=($(echo $1 | sed 's/,/ /g'))
+  if [ ${idx} -lt 0 ]; then
+    return
+  fi
+  idx_max[${idx}]=${#PARAM[@]}
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r)
+      shift
+      set_param "number of rpcs" 0 $1
+      rpcs=(${PARAM[@]})
+      shift
+      ;;
+    -c)
+      shift
+      set_param "number of connections" 1 $1
+      conns=(${PARAM[@]})
+      shift
+      ;;
+    -w)
+      shift
+      set_param "warm-up period" -1 $1
+      warmup=${PARAM}
+      shift
+      ;;
+    -d)
+      shift
+      set_param "duration" -1 $1
+      dur=${PARAM}
+      shift
+      ;;
+    -req)
+      shift
+      set_param "request size" 2 $1
+      reqs=(${PARAM[@]})
+      shift
+      ;;
+    -resp)
+      shift
+      set_param "response size" 3 $1
+      resps=(${PARAM[@]})
+      shift
+      ;;
+    -rpc_type)
+      shift
+      set_param "rpc type" 4 $1
+      rpc_types=(${PARAM[@]})
+      shift
+      ;;
+    -h|--help)
+      echo "Following are valid options:"
+      echo
+      echo "-h, --help        show brief help"
+      echo "-w                warm-up duration in seconds, default value is 10"
+      echo "-d                benchmark duration in seconds, default value is 60"
+      echo ""
+      echo "Each of the following can have multiple comma separated values."
+      echo ""
+      echo "-r                number of RPCs, default value is 1"
+      echo "-c                number of Connections, default value is 1"
+      echo "-req              req size in bytes, default value is 1"
+      echo "-resp             resp size in bytes, default value is 1"
+      echo "-rpc_type         valid values are unary|streaming, default is unary"
+      exit 0
+      ;;
+    *)
+      echo "Incorrect option $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Build server and client
+if [ $? != 0 ]; then
+  clean_and_die 1
+fi
+
+
+while :
+do
+  run
+  inc
+done

--- a/demos/golang/grpc_benchmark/run_host_server.sh
+++ b/demos/golang/grpc_benchmark/run_host_server.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export GOPATH=$PWD
+out_dir=$PWD/bin
+port=50051
+# Launch the server in background
+${out_dir}/server --port=${port} --test_name="Server_gRPC"&
+server_pid=$(echo $!)
+echo "server_pid = $server_pid"

--- a/demos/golang/grpc_benchmark/run_occlum_bench.sh
+++ b/demos/golang/grpc_benchmark/run_occlum_bench.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+set -e
+
+rpcs=(1)
+conns=(1)
+warmup=10
+dur=10
+reqs=(1)
+resps=(1)
+rpc_types=(unary)
+#ip="localhost"
+
+out_dir=$PWD/bin
+# idx[0] = idx value for rpcs
+# idx[1] = idx value for conns
+# idx[2] = idx value for reqs
+# idx[3] = idx value for resps
+# idx[4] = idx value for rpc_types
+idx=(0 0 0 0 0)
+idx_max=(1 1 1 1 1)
+
+
+
+# 1. Init Occlum Workspace
+rm -rf occlum_instance && mkdir occlum_instance
+cd occlum_instance
+occlum init
+new_json="$(jq '.resource_limits.user_space_size = "4096MB" |
+	        .resource_limits.max_num_of_threads = 96 |
+                .process.default_mmap_size = "300MB"' Occlum.json)" && \
+echo "${new_json}" > Occlum.json
+
+# 2. Copy program into Occlum Workspace and build
+cp ${out_dir}/* image/bin
+mkdir -p image/etc
+cp /etc/hosts image/etc
+occlum build
+
+inc()
+{
+  for i in $(seq $((${#idx[@]}-1)) -1 0); do
+    idx[${i}]=$((${idx[${i}]}+1))
+    if [ ${idx[${i}]} == ${idx_max[${i}]} ]; then
+      idx[${i}]=0
+    else
+      break
+    fi
+  done
+  local fin
+  fin=1
+  # Check to see if we have looped back to the beginning.
+  for v in ${idx[@]}; do
+    if [ ${v} != 0 ]; then
+      fin=0
+      break
+    fi
+  done
+  if [ ${fin} == 1 ]; then
+    clean_and_die 0
+  fi
+}
+
+clean_and_die() {
+  exit $1
+}
+
+
+run(){
+  local nr
+  nr=${rpcs[${idx[0]}]}
+  local nc
+  nc=${conns[${idx[1]}]}
+  req_sz=${reqs[${idx[2]}]}
+  resp_sz=${resps[${idx[3]}]}
+  r_type=${rpc_types[${idx[4]}]}
+  # Following runs one benchmark
+  base_port=50051
+  delta=0
+  test_name="r_"${nr}"_c_"${nc}"_req_"${req_sz}"_resp_"${resp_sz}"_"${r_type}"_"$(date +%s)
+  echo "================================================================================"
+  echo ${test_name}
+  while :
+  do
+    port=$((${base_port}+${delta}))
+
+    # Launch the server in background
+    occlum exec /bin/server --port=${port} --test_name="Server_"${test_name}&
+    server_pid=$(echo $!)
+
+    # Launch the client
+    occlum exec /bin/client --port=${port} --d=${dur} --w=${warmup} --r=${nr} --c=${nc} --req=${req_sz} --resp=${resp_sz} --rpc_type=${r_type}  --test_name="client_"${test_name}
+    client_status=$(echo $?)
+
+    kill -INT ${server_pid}
+    #wait ${server_pid}
+
+    if [ ${client_status} == 0 ]; then
+      echo "stop server"
+      occlum stop
+      break
+    fi
+
+    delta=$((${delta}+1))
+    if [ ${delta} == 10 ]; then
+      echo "Continuous 10 failed runs. Exiting now."
+    fi
+  done
+
+}
+
+set_param(){
+  local argname=$1
+  shift
+  local idx=$1
+  shift
+  if [ $# -eq 0 ]; then
+    echo "${argname} not specified"
+    exit 1
+  fi
+  PARAM=($(echo $1 | sed 's/,/ /g'))
+  if [ ${idx} -lt 0 ]; then
+    return
+  fi
+  idx_max[${idx}]=${#PARAM[@]}
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r)
+      shift
+      set_param "number of rpcs" 0 $1
+      rpcs=(${PARAM[@]})
+      shift
+      ;;
+    -c)
+      shift
+      set_param "number of connections" 1 $1
+      conns=(${PARAM[@]})
+      shift
+      ;;
+    -w)
+      shift
+      set_param "warm-up period" -1 $1
+      warmup=${PARAM}
+      shift
+      ;;
+    -d)
+      shift
+      set_param "duration" -1 $1
+      dur=${PARAM}
+      shift
+      ;;
+    -req)
+      shift
+      set_param "request size" 2 $1
+      reqs=(${PARAM[@]})
+      shift
+      ;;
+    -resp)
+      shift
+      set_param "response size" 3 $1
+      resps=(${PARAM[@]})
+      shift
+      ;;
+    -rpc_type)
+      shift
+      set_param "rpc type" 4 $1
+      rpc_types=(${PARAM[@]})
+      shift
+      ;;
+    -h|--help)
+      echo "Following are valid options:"
+      echo
+      echo "-h, --help        show brief help"
+      echo "-w                warm-up duration in seconds, default value is 10"
+      echo "-d                benchmark duration in seconds, default value is 60"
+      echo ""
+      echo "Each of the following can have multiple comma separated values."
+      echo ""
+      echo "-r                number of RPCs, default value is 1"
+      echo "-c                number of Connections, default value is 1"
+      echo "-req              req size in bytes, default value is 1"
+      echo "-resp             resp size in bytes, default value is 1"
+      echo "-rpc_type         valid values are unary|streaming, default is unary"
+      exit 0
+      ;;
+    *)
+      echo "Incorrect option $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Build server and client
+if [ $? != 0 ]; then
+  clean_and_die 1
+fi
+
+occlum start
+while :
+do
+  run
+  inc
+done

--- a/demos/golang/grpc_benchmark/run_occlum_server.sh
+++ b/demos/golang/grpc_benchmark/run_occlum_server.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+out_dir=$PWD/bin
+
+
+
+# 1. Init Occlum Workspace
+rm -rf occlum_instance && mkdir occlum_instance
+cd occlum_instance
+occlum init
+new_json="$(jq '.resource_limits.user_space_size = "4096MB" |
+	        .resource_limits.max_num_of_threads = 96 |
+                .process.default_mmap_size = "300MB"' Occlum.json)" && \
+echo "${new_json}" > Occlum.json
+
+# 2. Copy program into Occlum Workspace and build
+cp ${out_dir}/* image/bin
+mkdir -p image/etc
+cp /etc/hosts image/etc
+occlum build
+# Following runs one benchmark
+port=50051
+echo "================================================================================"
+echo "gRPC Server"
+# Launch the server in background
+occlum run /bin/server --port=${port} --test_name="Server_gRPC"&
+
+

--- a/demos/sqlite/download_and_build_sqlite.sh
+++ b/demos/sqlite/download_and_build_sqlite.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 set -e
 
-SQLITE=sqlite-autoconf-3310100
+SQLITE=sqlite-autoconf-3330000
 SQLITE_SRC=sqlite_src
 DEMO=sqlite_demo
+SPEEDTEST=speedtest1
 
 # Download SQLite source files
 [ ! -d $SQLITE_SRC ] && rm -f $SQLITE.tar.gz && \
-               wget http://www3.sqlite.org/2020/$SQLITE.tar.gz \
+               wget http://www.sqlite.org/2020/$SQLITE.tar.gz \
                && rm -rf $SQLITE && tar xf $SQLITE.tar.gz \
                && mv $SQLITE $SQLITE_SRC \
                && rm -f $SQLITE.tar.gz
-
 [ -e $DEMO ] && rm -f $DEMO
 echo -e "Starting to build $DEMO ..."
 occlum-gcc -O2 -I$SQLITE_SRC sqlite_demo.c $SQLITE_SRC/sqlite3.c -lpthread -ldl -o $DEMO
 echo -e "Build $DEMO succeed"
+
+[ -e $SPEEDTEST ] && rm -f $SPEEDTEST && rm -f $SPEEDTEST.c
+echo -e "Starting to build $SPEEDTEST ..."
+wget https://raw.githubusercontent.com/sqlite/sqlite/version-3.33.0/test/$SPEEDTEST.c
+occlum-gcc -O6 -I$SQLITE_SRC -DNDEBUG=1 -DSQLITE_ENABLE_MEMSYS5 -DSQLITE_THREADSAFE=2 -DSQLITE_DEFAULT_WORKER_THREADS=32 $SPEEDTEST.c $SQLITE_SRC/sqlite3.c -lpthread -ldl -o $SPEEDTEST
+echo -e "Build $SPEEDTEST succeed"
+

--- a/demos/sqlite/run_sqlite_on_occlum.sh
+++ b/demos/sqlite/run_sqlite_on_occlum.sh
@@ -11,10 +11,17 @@ SQL_STMT="CREATE TABLE COMPANY ( \
     SALARY REAL ); \
     INSERT INTO COMPANY VALUES ( 1, 'Kris', 27, 'California', 16000.00 ); \
     SELECT * FROM COMPANY;"
+SPEEDTEST=speedtest1
 
 if [ ! -e $DEMO ];then
     echo "Error: cannot stat '$DEMO'"
     echo "Please see README and build the $DEMO"
+    exit 1
+fi
+
+if [ ! -e $SPEEDTEST ];then
+    echo "Error: cannot stat '$SPEEDTEST'"
+    echo "Please see README and build the $SPEEDTEST"
     exit 1
 fi
 
@@ -25,7 +32,9 @@ occlum init
 
 # 2. Copy files into Occlum Workspace and build
 cp ../$DEMO image/bin
+cp ../$SPEEDTEST image/bin
 occlum build
 
 # 3. Run the demo
 occlum run /bin/$DEMO "$SQL_DB" "$SQL_STMT"
+occlum run /bin/$SPEEDTEST --memdb --stats --size 100

--- a/demos/xgboost/download_and_build_xgboost.sh
+++ b/demos/xgboost/download_and_build_xgboost.sh
@@ -13,7 +13,7 @@ pip3 install kubernetes
 rm -rf xgboost_src && mkdir xgboost_src
 pushd xgboost_src
 git clone https://github.com/dmlc/xgboost .
-git checkout 6d5b34d82486cd1d0480c548f5d1953834659bd6
+git checkout 9e955fb9b06cac32a06c92c4715f749d9d87e932
 git submodule init
 git submodule update
 git apply ../patch/xgboost-01.diff


### PR DESCRIPTION
Copied and Modified the google.golang.org/grpc/benchmark/run_bench.sh to
support the remote benchmark and benchmark with occlum.

Signed-off-by: yuanwu <yuan.wu@intel.com>