### PR TITLE
Put the shebang in the front of run_occlum_bench.sh

### DIFF
--- a/demos/golang/grpc_benchmark/run_occlum_bench.sh
+++ b/demos/golang/grpc_benchmark/run_occlum_bench.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #*
 #*
 #* Copyright 2014 gRPC authors.
@@ -15,8 +16,6 @@
 #* limitations under the License.
 #*
 
-
-#!/bin/bash
 set -e
 
 rpcs=(1)


### PR DESCRIPTION
Exec parses the script according to the shebang.