### PR TITLE
Fix package build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/libsgx_uae_service_sim.so: /opt/intel/sgxsdk
 	@mkdir -p $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/gdb-sgx-plugin
 	@cd /opt/intel/sgxsdk/lib64/gdb-sgx-plugin/ && cp $$(ls -A | grep -v __pycache__) $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/gdb-sgx-plugin
 	@cd /opt/intel/sgxsdk && cp -a --parents {bin/sgx-gdb,bin/x64/sgx_sign} $(OCCLUM_PREFIX)/sgxsdk-tools/
-	@mkdir -p $(OCCLUM_PREFIX)/sgxsdk-tools/sdk_libs && \
-		ln -sf $(OCCLUM_PREFIX)/sgxsdk-tools/lib64/libsgx_uae_service_sim.so $(OCCLUM_PREFIX)/sgxsdk-tools/sdk_libs/libsgx_uae_service_sim.so
+	@mkdir -p $(OCCLUM_PREFIX)/sgxsdk-tools/sdk_libs && cd $(OCCLUM_PREFIX)/sgxsdk-tools/sdk_libs && \
+		ln -sf ../lib64/libsgx_uae_service_sim.so libsgx_uae_service_sim.so
 	@# Delete SGX_LIBRARY_PATH env in sgx-gdb which are defined in etc/environment
 	@sed -i '/^SGX_LIBRARY_PATH=/d' $(OCCLUM_PREFIX)/sgxsdk-tools/bin/sgx-gdb
 	@cp etc/environment $(OCCLUM_PREFIX)/sgxsdk-tools/

--- a/src/run/Makefile
+++ b/src/run/Makefile
@@ -7,7 +7,7 @@ C_OBJS := $(addprefix $(OBJ_DIR)/run/,$(C_SRCS:.c=.o))
 
 C_COMMON_FLAGS := -I$(PROJECT_DIR)/src/pal/include
 C_FLAGS := $(C_COMMON_FLAGS) $(SGX_CFLAGS_U)
-LINK_FLAGS := $(SGX_LFLAGS_U) -L$(BUILD_DIR)/lib -lsgx_uprotected_fs -locclum-pal
+LINK_FLAGS := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -L$(BUILD_DIR)/lib -lsgx_uprotected_fs -locclum-pal
 
 ALL_BUILD_SUBDIRS := $(sort $(patsubst %/,%,$(dir $(BIN) $(C_OBJS))))
 

--- a/tools/installer/deb/toolchains/gcc/rules
+++ b/tools/installer/deb/toolchains/gcc/rules
@@ -15,6 +15,12 @@ MUSL_REPO = https://github.com/occlum/musl
 MUSL_VER = 1.1.24
 GCC_VER = 8.3.0
 
+# Users can pass "-j$(nproc)" by specifying this env.
+# This is not enabled by default because under certain scenarios,
+# make will use too many jobs and gcc will be killed because out
+# of memory.
+BUILD_OPTIONS +=
+
 .ONESHELL: prepare_musl override_dh_install
 
 %:
@@ -41,7 +47,7 @@ prepare_musl:
 
 override_dh_auto_build: prepare_musl
 	cd $(tmp_build_dir)/musl-cross-make; \
-		make -j$(nproc)
+		make $(BUILD_OPTIONS)
 
 # We create symlinks in /usr/local
 override_dh_usrlocal:

--- a/tools/installer/rpm/occlum-filelist
+++ b/tools/installer/rpm/occlum-filelist
@@ -1,5 +1,4 @@
 /opt/occlum/build/bin/gen_internal_conf
-/opt/occlum/build/bin/occlum-gen-default-occlum-json
 /opt/occlum/build/bin/occlum-protect-integrity
 /opt/occlum/build/bin/sefs-cli
 /opt/occlum/build/bin/sefs-cli_sim


### PR DESCRIPTION
1. Fix repeatedly linking dynamic libraries for occlum-run
2. Fix gcc toolchain deb package build error
3. Remove redundant file from installer file list
4. Change symlink target path to relative path