### PR TITLE
Compile using sccache if it is installed

### DIFF
--- a/src/exec/Makefile
+++ b/src/exec/Makefile
@@ -8,12 +8,18 @@ EXEC_TARGET := $(RUST_OUT_DIR)/*occlum_exec*
 
 .PHONY: all clean
 
+ifneq (, $(shell which sccache))
+    RUSTC_WRAPPER := sccache
+else
+    RUSTC_WRAPPER :=
+endif
+
 all: $(SRC_FILES)
 ifeq ($(OCCLUM_RELEASE_BUILD), 1)
-	@RUSTC_BOOTSTRAP=1 cargo build --release --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
+	@RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=$(RUSTC_WRAPPER) cargo build --release --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
 	@echo "CARGO (release) => exec"
 else
-	@RUSTC_BOOTSTRAP=1 cargo build --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
+	@RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=$(RUSTC_WRAPPER) cargo build --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
 	@echo "CARGO (debug) => exec"
 endif
 

--- a/src/libos/Makefile
+++ b/src/libos/Makefile
@@ -106,13 +106,19 @@ $(LIBOS_CORE_A): $(LIBOS_CORE_RS_A) $(C_OBJS) $(CXX_OBJS) $(S_OBJS) $(EDL_C_OBJS
 	@ar r $@ $(C_OBJS) $(CXX_OBJS) $(S_OBJS) $(EDL_C_OBJS)
 	@echo "GEN => $@"
 
+ifneq (, $(shell which sccache))
+    RUSTC_WRAPPER := sccache
+else
+    RUSTC_WRAPPER :=
+endif
+
 ifeq ($(OCCLUM_RELEASE_BUILD), 1)
 $(LIBOS_CORE_RS_A): $(RUST_SRCS)
-	@RUSTC_BOOTSTRAP=1 cargo build --release --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
+	@RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=$(RUSTC_WRAPPER) cargo build --release --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
 	@echo "CARGO (release) => $@"
 else
 $(LIBOS_CORE_RS_A): $(RUST_SRCS)
-	@RUSTC_BOOTSTRAP=1 cargo build --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
+	@RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=$(RUSTC_WRAPPER) cargo build --target-dir=$(RUST_TARGET_DIR) -Z unstable-options --out-dir=$(RUST_OUT_DIR)
 	@echo "CARGO (debug) => $@"
 endif
 

--- a/tools/docker/Dockerfile.centos7.5
+++ b/tools/docker/Dockerfile.centos7.5
@@ -93,7 +93,8 @@ ENV OCCLUM_RUST_VERSION=nightly-2020-04-07
 RUN curl https://sh.rustup.rs -sSf | \
         sh -s -- --default-toolchain ${OCCLUM_RUST_VERSION} -y && \
     rm -rf /root/.cargo/registry && rm -rf /root/.cargo/git && \
-    cargo -V
+    cargo -V && \
+    cargo install sccache
 
 # Install Occlum toolchain
 COPY toolchains/gcc /tmp/gcc

--- a/tools/docker/Dockerfile.centos8.1
+++ b/tools/docker/Dockerfile.centos8.1
@@ -63,7 +63,8 @@ ENV OCCLUM_RUST_VERSION=nightly-2020-09-08
 RUN curl https://sh.rustup.rs -sSf | \
         sh -s -- --default-toolchain ${OCCLUM_RUST_VERSION} -y && \
     rm -rf /root/.cargo/registry && rm -rf /root/.cargo/git && \
-    cargo -V
+    cargo -V && \
+    cargo install sccache
 
 # Install Occlum toolchain
 COPY toolchains/gcc /tmp/gcc

--- a/tools/docker/Dockerfile.ubuntu18.04
+++ b/tools/docker/Dockerfile.ubuntu18.04
@@ -75,7 +75,8 @@ ENV OCCLUM_RUST_VERSION=nightly-2020-09-08
 RUN curl https://sh.rustup.rs -sSf | \
         sh -s -- --default-toolchain ${OCCLUM_RUST_VERSION} -y && \
     rm -rf /root/.cargo/registry && rm -rf /root/.cargo/git && \
-    cargo -V
+    cargo -V && \
+    cargo install sccache
 
 # Install Occlum toolchain
 COPY toolchains/gcc /tmp/gcc


### PR DESCRIPTION
Using sccache accelerates the compilation when the cache is hit. Especially, `make clean` and then `make` saves seconds.