### PR TITLE
Fix the conflict of symbols with glibc

### DIFF
--- a/src/pal/src/ocalls/event.c
+++ b/src/pal/src/ocalls/event.c
@@ -22,7 +22,7 @@ int occlum_ocall_eventfd_poll(int eventfd, struct timespec *timeout) {
     // is because the syscall version updates the timeout argument to indicate
     // how much time was left (which what we want), while the libc wrapper
     // keeps the timeout argument unchanged.
-    ret = raw_ppoll(pollfds, 1, timeout);
+    ret = RAW_PPOLL(pollfds, 1, timeout);
     if (ret < 0) {
         return -1;
     }

--- a/src/pal/src/ocalls/sched.c
+++ b/src/pal/src/ocalls/sched.c
@@ -9,7 +9,7 @@ int occlum_ocall_sched_getaffinity(size_t cpusize, unsigned char *buf) {
     cpu_set_t mask;
     CPU_ZERO(&mask);
 
-    ret = syscall(__NR_sched_getaffinity, gettid(), sizeof(cpu_set_t), &mask);
+    ret = syscall(__NR_sched_getaffinity, GETTID(), sizeof(cpu_set_t), &mask);
     memcpy(buf, &mask, cpusize);
     return ret;
 }

--- a/src/pal/src/ocalls/signal.c
+++ b/src/pal/src/ocalls/signal.c
@@ -2,6 +2,6 @@
 
 int occlum_ocall_tkill(int tid, int signum) {
     int tgid = getpid();
-    int ret = tgkill(tgid, tid, signum);
+    int ret = TGKILL(tgid, tid, signum);
     return ret;
 }

--- a/src/pal/src/ocalls/spawn.c
+++ b/src/pal/src/ocalls/spawn.c
@@ -11,7 +11,7 @@ typedef struct {
 void *exec_libos_thread(void *_thread_data) {
     thread_data_t *thread_data = _thread_data;
     sgx_enclave_id_t eid = thread_data->enclave_id;
-    int host_tid = gettid();
+    int host_tid = GETTID();
     int libos_tid = thread_data->libos_tid;
     int libos_exit_status = -1;
     sgx_status_t status = occlum_ecall_exec_thread(eid, &libos_exit_status, libos_tid,

--- a/src/pal/src/pal_api.c
+++ b/src/pal/src/pal_api.c
@@ -109,7 +109,7 @@ int occlum_pal_create_process(struct occlum_pal_create_process_args *args) {
 }
 
 int occlum_pal_exec(struct occlum_pal_exec_args *args) {
-    int host_tid = gettid();
+    int host_tid = GETTID();
     int ecall_ret = 0;
 
     if (args->exit_value == NULL) {

--- a/src/pal/src/pal_syscall.h
+++ b/src/pal/src/pal_syscall.h
@@ -8,10 +8,10 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#define gettid()                        ((pid_t)syscall(__NR_gettid))
-#define tgkill(tgid, tid, signum)       ((int)syscall(__NR_tgkill, (tgid), (tid), (signum)));
-#define futex_wait(addr, val, timeout)  ((int)syscall(__NR_futex, (addr), FUTEX_WAIT, (val), (timeout)))
-#define futex_wake(addr)                ((int)syscall(__NR_futex, (addr), FUTEX_WAKE, 1))
-#define raw_ppoll(fds, nfds, timeout)   ((int)syscall(__NR_ppoll, (fds), (nfds), (timeout), NULL, 0))
+#define GETTID()                        ((pid_t)syscall(__NR_gettid))
+#define TGKILL(tgid, tid, signum)       ((int)syscall(__NR_tgkill, (tgid), (tid), (signum)))
+#define FUTEX_WAIT_TIMEOUT(addr, val, timeout)  ((int)syscall(__NR_futex, (addr), FUTEX_WAIT, (val), (timeout)))
+#define FUTEX_WAKE_ONE(addr)                ((int)syscall(__NR_futex, (addr), FUTEX_WAKE, 1))
+#define RAW_PPOLL(fds, nfds, timeout)   ((int)syscall(__NR_ppoll, (fds), (nfds), (timeout), NULL, 0))
 
 #endif /* __PAL_SYSCALL_H__ */

--- a/src/pal/src/pal_thread_counter.c
+++ b/src/pal/src/pal_thread_counter.c
@@ -12,7 +12,7 @@ void pal_thread_counter_dec(void) {
     int val = __atomic_sub_fetch(&pal_thread_counter, 1, __ATOMIC_SEQ_CST);
     assert(val >= 0);
 
-    (void)futex_wake(&pal_thread_counter);
+    (void)FUTEX_WAKE_ONE(&pal_thread_counter);
 }
 
 int pal_thread_counter_get(void) {
@@ -23,7 +23,7 @@ int pal_thread_counter_wait_zero(const struct timespec *timeout) {
     int old_val = pal_thread_counter_get();
     if (old_val == 0) { return 0; }
 
-    (void)futex_wait(&pal_thread_counter, old_val, timeout);
+    (void)FUTEX_WAIT_TIMEOUT(&pal_thread_counter, old_val, timeout);
 
     int new_val = pal_thread_counter_get();
     return new_val;


### PR DESCRIPTION
`tgkill` and `gettid` are defined in the high-version glibc. Refer to the man page of `tgkill` and `gettid` for more details. Besides, C macro is usually upper-case. This conflict is found in alios7u2.