### PR TITLE
Add the new poll implementation

### DIFF
--- a/src/libos/src/fs/dev_fs/dev_null.rs
+++ b/src/libos/src/fs/dev_fs/dev_null.rs
@@ -16,6 +16,10 @@ impl File for DevNull {
         Ok(bufs.iter().map(|buf| buf.len()).sum())
     }
 
+    fn poll_new(&self) -> IoEvents {
+        IoEvents::IN
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/libos/src/fs/dev_fs/dev_random.rs
+++ b/src/libos/src/fs/dev_fs/dev_random.rs
@@ -64,6 +64,10 @@ impl File for DevRandom {
         Ok(PollEventFlags::POLLIN)
     }
 
+    fn poll_new(&self) -> IoEvents {
+        IoEvents::IN
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/libos/src/fs/dev_fs/dev_sgx/mod.rs
+++ b/src/libos/src/fs/dev_fs/dev_sgx/mod.rs
@@ -95,6 +95,10 @@ impl File for DevSgx {
         Ok(0)
     }
 
+    fn poll_new(&self) -> IoEvents {
+        IoEvents::IN
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/libos/src/fs/dev_fs/dev_zero.rs
+++ b/src/libos/src/fs/dev_fs/dev_zero.rs
@@ -23,6 +23,10 @@ impl File for DevZero {
         Ok(total_nbytes)
     }
 
+    fn poll_new(&self) -> IoEvents {
+        IoEvents::IN
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/libos/src/fs/events.rs
+++ b/src/libos/src/fs/events.rs
@@ -2,13 +2,37 @@ use crate::events::{Event, EventFilter, Notifier, Observer};
 use crate::prelude::*;
 
 bitflags! {
+    /// I/O Events
+    #[rustfmt::skip]
     pub struct IoEvents: u32 {
-        const IN = 0x001; // = POLLIN
-        const OUT = 0x004; // = POLLOUT
-        const PRI = 0x002; // = POLLPRI
-        const ERR = 0x008; // = POLLERR
+        const IN    = 0x0001; // = POLLIN
+        const PRI   = 0x0002; // = POLLPRI
+        const OUT   = 0x0004; // = POLLOUT
+        const ERR   = 0x0008; // = POLLERR
+        const HUP   = 0x0010; // = POLLHUP
+        const NVAL  = 0x0020; // = POLLNVAL
         const RDHUP = 0x2000; // = POLLRDHUP
-        const HUP = 0x010; // = POLLHUP
+    }
+}
+
+impl IoEvents {
+    pub fn from_raw(raw: u32) -> Self {
+        if Self::contains_unrecognizable_bits(raw) {
+            warn!("contain unknow flags: {:#x}", raw);
+        }
+        Self::from_bits_truncate(raw)
+    }
+
+    fn contains_unrecognizable_bits(raw: u32) -> bool {
+        // Help to detect four valid but mostly useless flags that we do not
+        // handle, yet: POLLRDNORM, POLLRDBAND, POLLWRNORM, annd POLLWRBAND.
+
+        let all_raw = Self::all().to_raw();
+        (raw & !all_raw) != 0
+    }
+
+    pub fn to_raw(&self) -> u32 {
+        self.bits()
     }
 }
 

--- a/src/libos/src/net/io_multiplexing/epoll/host_file_epoller.rs
+++ b/src/libos/src/net/io_multiplexing/epoll/host_file_epoller.rs
@@ -156,7 +156,7 @@ impl HostFileEpoller {
         let mut host_files = self.host_files.lock().unwrap();
         for raw_event in &raw_events[..count] {
             let raw_event = unsafe { raw_event.assume_init() };
-            let io_events = IoEvents::from_bits_truncate(raw_event.events as u32);
+            let io_events = IoEvents::from_raw(raw_event.events as u32);
             let host_fd = raw_event.u64 as u32;
 
             let host_file = match host_files.get(&host_fd) {

--- a/src/libos/src/net/io_multiplexing/epoll/mod.rs
+++ b/src/libos/src/net/io_multiplexing/epoll/mod.rs
@@ -55,7 +55,7 @@ impl EpollEvent {
     }
 
     pub fn from_c(c_event: &libc::epoll_event) -> Self {
-        let mask = IoEvents::from_bits_truncate(c_event.events as u32);
+        let mask = IoEvents::from_raw(c_event.events as u32);
         let user_data = c_event.u64;
         Self { mask, user_data }
     }

--- a/src/libos/src/net/io_multiplexing/mod.rs
+++ b/src/libos/src/net/io_multiplexing/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod epoll;
+mod poll_new;
 // TODO: the following three modules will soon be removed
 mod io_event;
 mod poll;
@@ -11,6 +12,7 @@ pub use self::io_event::{
     clear_notifier_status, notify_thread, wait_for_notification, IoEvent, THREAD_NOTIFIERS,
 };
 pub use self::poll::{do_poll, PollEvent, PollEventFlags};
+pub use self::poll_new::{do_poll_new, PollFd};
 pub use self::select::{select, FdSetExt};
 
 use fs::{AsDevRandom, AsEvent, CreationFlags, File, FileDesc, FileRef, HostFd, PipeType};

--- a/src/libos/src/net/io_multiplexing/poll_new/event_monitor.rs
+++ b/src/libos/src/net/io_multiplexing/poll_new/event_monitor.rs
@@ -1,0 +1,303 @@
+use std::cell::Cell;
+use std::ptr;
+use std::sync::Weak;
+use std::time::Duration;
+
+use crate::events::{Observer, Waiter, WaiterQueueObserver};
+use crate::fs::IoEvents;
+use crate::prelude::*;
+use crate::time::{timespec_t, TIMERSLACK};
+
+/// Monitor events that happen on a set of interesting files.
+///
+/// The event monitor can wait for events on both LibOS files and host files.
+/// Event better, as a result of waiting for the events of host files, the
+/// states of host files (returned by the `poll` method) are also updated.
+pub struct EventMonitor {
+    // The set of interesting files and their events.
+    files_and_events: Vec<(FileRef, IoEvents)>,
+    // The indexes of host files inside the set of the interesting files.
+    host_file_idxes: Vec<usize>,
+    // An array of struct pollfd as the argument for the poll syscall via OCall.
+    //
+    // The items in `ocall_pollfds` corresponds to the items in
+    // `host_file_idxes` on a one-on-one basis, except the last item in
+    // `ocall_pollfds`. This indicates that `ocall_pollfds.len() ==
+    // host_files_idxes.len() + 1`.
+    ocall_pollfds: Vec<libc::pollfd>,
+    // An observer and also a waiter queue.
+    observer: Arc<WaiterQueueObserver<IoEvents>>,
+    // A waiter.
+    //
+    // The last two fields comprise of a common pattern enabled by the event
+    // subsystem.
+    waiter: Waiter,
+}
+
+impl EventMonitor {
+    /// Returns an iterator for the set of the interesting files.
+    pub fn files(&self) -> impl Iterator<Item = &FileRef> {
+        self.files_and_events.iter().map(|(file, _)| file)
+    }
+
+    /// Returns an iterator for the host files in the set of the interesting files.
+    pub fn host_files(&self) -> impl Iterator<Item = &FileRef> {
+        self.host_file_idxes
+            .iter()
+            .map(move |idx| &self.files_and_events[*idx].0)
+    }
+
+    /// Reset the monitor so that it can wait for new events.
+    pub fn reset_events(&mut self) {
+        self.observer.waiter_queue().reset_and_enqueue(&self.waiter);
+    }
+
+    /// Wait for some interesting events that happen on the set of files.
+    ///
+    /// To make the code more efficient, this method also polls the states of
+    /// the host files in the set and updates their states accordingly.
+    ///
+    /// The signature of this method gets a bit of complicated to fight with
+    /// Rust's move semantics. The ownership of the `timeout` argument is moved
+    /// from the caller to this function. To give the `timeout` argument back to
+    /// the caller (so that he or she can repeatedly use the argument in a
+    /// loop), we return the `timeout` inside `Result::Ok`.
+    pub fn wait_events<'a, 'b>(
+        &'a mut self,
+        mut timeout: Option<&'b mut Duration>,
+    ) -> Result<Option<&'b mut Duration>> {
+        const ZERO: Duration = Duration::from_secs(0);
+        if let Some(timeout) = timeout.as_ref() {
+            if **timeout == ZERO {
+                return_errno!(ETIMEDOUT, "should return immediately");
+            }
+        }
+
+        // The do_ocall method returns when one of the following conditions is satisfied:
+        // 1. self.waiter is waken, indicating some interesting events happen on the LibOS files;
+        // 2. some interesting events happen on the host files;
+        // 3. a signal arrives;
+        // 4. the time is up.
+        let num_events = self.do_poll_ocall(&mut timeout)?;
+
+        self.recv_host_file_events(num_events);
+
+        // Poll syscall does not treat timeout as error. So we need
+        // to distinguish the case by ourselves.
+        if let Some(timeout) = timeout.as_mut() {
+            if num_events == 0 {
+                **timeout = ZERO;
+                return_errno!(ETIMEDOUT, "no results and the time is up");
+            }
+        }
+        assert!(num_events > 0);
+
+        Ok(timeout)
+    }
+
+    /// Poll the host files among the set of the interesting files and update
+    /// their states accordingly.
+    pub fn poll_host_files(&mut self) {
+        let mut zero_timeout = Some(Duration::from_secs(0));
+        let num_events = match self.do_poll_ocall(&mut zero_timeout.as_mut()) {
+            Ok(num_events) => num_events,
+            Err(_) => return,
+        };
+
+        self.recv_host_file_events(num_events);
+    }
+
+    fn do_poll_ocall(&mut self, timeout: &mut Option<&mut Duration>) -> Result<usize> {
+        extern "C" {
+            fn occlum_ocall_poll_with_eventfd(
+                ret: *mut i32,
+                fds: *mut libc::pollfd,
+                nfds: u32,
+                timeout: *mut timespec_t,
+                eventfd_idx: i32,
+            ) -> sgx_status_t;
+        }
+
+        // Do poll syscall via OCall
+        let num_events = try_libc!({
+            let mut remain_c = timeout.as_ref().map(|timeout| timespec_t::from(**timeout));
+            let remain_c_ptr = remain_c.as_mut().map_or(ptr::null_mut(), |mut_ref| mut_ref);
+
+            let host_eventfd_idx = self.ocall_pollfds.len() - 1;
+
+            let mut ret = 0;
+            let status = unsafe {
+                occlum_ocall_poll_with_eventfd(
+                    &mut ret,
+                    (&mut self.ocall_pollfds[..]).as_mut_ptr(),
+                    self.ocall_pollfds.len() as u32,
+                    remain_c_ptr,
+                    host_eventfd_idx as i32,
+                )
+            };
+            assert!(status == sgx_status_t::SGX_SUCCESS);
+
+            if let Some(timeout) = timeout.as_mut() {
+                let remain = remain_c.unwrap().as_duration();
+                assert!(remain <= **timeout + TIMERSLACK.to_duration());
+                **timeout = remain;
+            }
+
+            ret
+        }) as usize;
+        Ok(num_events)
+    }
+
+    fn recv_host_file_events(&self, num_events: usize) {
+        if num_events == 0 {
+            return;
+        }
+
+        // According to the output pollfds, update the states of the corresponding host files
+        let output_pollfds = self.ocall_pollfds[..self.ocall_pollfds.len() - 1].iter();
+        for (pollfd, host_file) in output_pollfds.zip(self.host_files()) {
+            let revents = {
+                if pollfd.revents == 0 {
+                    continue;
+                }
+                assert!((pollfd.revents & libc::POLLNVAL) == 0);
+                IoEvents::from_raw(pollfd.revents as u32)
+            };
+            host_file.recv_host_events(&revents, false);
+        }
+    }
+}
+
+impl Drop for EventMonitor {
+    fn drop(&mut self) {
+        let weak_observer = Arc::downgrade(&self.observer) as Weak<dyn Observer<_>>;
+        weak_observer.unregister_files(self.files_and_events.iter());
+    }
+}
+
+pub struct EventMonitorBuilder {
+    files_and_events: Vec<(FileRef, IoEvents)>,
+    host_file_idxes: Vec<usize>,
+    ocall_pollfds: Vec<libc::pollfd>,
+    observer: Arc<WaiterQueueObserver<IoEvents>>,
+    waiter: Waiter,
+}
+
+impl EventMonitorBuilder {
+    pub fn new(expected_num_files: usize) -> Self {
+        let files_and_events = Vec::with_capacity(expected_num_files);
+        let host_file_idxes = Vec::new();
+        let ocall_pollfds = Vec::new();
+        let observer = WaiterQueueObserver::new();
+        let waiter = Waiter::new();
+        Self {
+            files_and_events,
+            host_file_idxes,
+            ocall_pollfds,
+            observer,
+            waiter,
+        }
+    }
+
+    pub fn add_file(&mut self, file: FileRef, events: IoEvents) {
+        let host_file_idx = if file.host_fd().is_some() {
+            Some(self.files_and_events.len())
+        } else {
+            None
+        };
+
+        self.files_and_events.push((file, events));
+
+        if let Some(host_file_idx) = host_file_idx {
+            self.host_file_idxes.push(host_file_idx);
+        }
+    }
+
+    fn init_ocall_pollfds(&mut self) {
+        let ocall_pollfds = &mut self.ocall_pollfds;
+
+        // For each host file, add a corresponding pollfd item
+        let files_and_events = &self.files_and_events;
+        let host_files_and_events = self
+            .host_file_idxes
+            .iter()
+            .map(move |idx| &files_and_events[*idx]);
+        for (file, events) in host_files_and_events {
+            ocall_pollfds.push(libc::pollfd {
+                fd: file.host_fd().unwrap().to_raw() as i32,
+                events: events.to_raw() as i16,
+                revents: 0,
+            });
+        }
+
+        // Add one more for waiter's underlying host eventfd
+        ocall_pollfds.push(libc::pollfd {
+            fd: self.waiter.host_eventfd().host_fd() as i32,
+            events: libc::POLLIN,
+            revents: 0,
+        });
+    }
+
+    fn init_observer(&self) {
+        let weak_observer = Arc::downgrade(&self.observer) as Weak<dyn Observer<_>>;
+        weak_observer.register_files(self.files_and_events.iter());
+    }
+
+    pub fn build(mut self) -> EventMonitor {
+        self.init_ocall_pollfds();
+        self.init_observer();
+
+        let mut new_event_monitor = {
+            let Self {
+                files_and_events,
+                host_file_idxes,
+                ocall_pollfds,
+                observer,
+                waiter,
+            } = self;
+            EventMonitor {
+                files_and_events,
+                host_file_idxes,
+                ocall_pollfds,
+                observer,
+                waiter,
+            }
+        };
+        new_event_monitor.poll_host_files();
+        new_event_monitor
+    }
+}
+
+// An extention trait to make registering/unregistering an observer for a
+// bunch of files easy.
+trait ObserverExt {
+    fn register_files<'a>(&self, files_and_events: impl Iterator<Item = &'a (FileRef, IoEvents)>);
+    fn unregister_files<'a>(&self, files_and_events: impl Iterator<Item = &'a (FileRef, IoEvents)>);
+}
+
+impl ObserverExt for Weak<dyn Observer<IoEvents>> {
+    fn register_files<'a>(&self, files_and_events: impl Iterator<Item = &'a (FileRef, IoEvents)>) {
+        for (file, events) in files_and_events {
+            let notifier = match file.notifier() {
+                None => continue,
+                Some(notifier) => notifier,
+            };
+
+            let mask = *events;
+            notifier.register(self.clone(), Some(mask), None);
+        }
+    }
+
+    fn unregister_files<'a>(
+        &self,
+        files_and_events: impl Iterator<Item = &'a (FileRef, IoEvents)>,
+    ) {
+        for (file, events) in files_and_events {
+            let notifier = match file.notifier() {
+                None => continue,
+                Some(notifier) => notifier,
+            };
+            notifier.unregister(self);
+        }
+    }
+}

--- a/src/libos/src/net/io_multiplexing/poll_new/mod.rs
+++ b/src/libos/src/net/io_multiplexing/poll_new/mod.rs
@@ -1,0 +1,136 @@
+use std::cell::Cell;
+use std::sync::Weak;
+use std::time::Duration;
+
+use crate::fs::IoEvents;
+use crate::prelude::*;
+
+use self::event_monitor::{EventMonitor, EventMonitorBuilder};
+
+mod event_monitor;
+
+// TODO: rename this to do_poll after the old version is removed
+pub fn do_poll_new(poll_fds: &[PollFd], mut timeout: Option<&mut Duration>) -> Result<usize> {
+    debug!("poll: poll_fds: {:?}, timeout: {:?}", poll_fds, timeout);
+
+    let thread = current!();
+    let files: Vec<FileRef> = poll_fds
+        .iter()
+        .filter_map(|poll_fd| {
+            let file = thread.file(poll_fd.fd).ok();
+
+            // Mark an invalid fd by outputting an IoEvents::NVAL event
+            if file.is_none() {
+                poll_fd.revents.set(IoEvents::NVAL);
+            }
+
+            file
+        })
+        .collect();
+
+    // If there are any invalid fds, then report errors as events
+    let num_invalid_fds = poll_fds.len() - files.len();
+    if num_invalid_fds > 0 {
+        return Ok(num_invalid_fds);
+    }
+
+    // Now that all fds are valid, we set up a monitor for the set of files
+    let mut monitor = {
+        let expected_num_files = files.len();
+        let mut builder = EventMonitorBuilder::new(expected_num_files);
+        for (file, poll_fd) in files.into_iter().zip(poll_fds.iter()) {
+            builder.add_file(file, poll_fd.events);
+        }
+        builder.build()
+    };
+
+    // Poll the set of files until success, timeout, or interruption.
+    loop {
+        monitor.reset_events();
+
+        // Poll each and every interesting file
+        let mut count = 0;
+        for (file, poll_fd) in monitor.files().zip(poll_fds.iter()) {
+            let mask = poll_fd.events;
+            let events = file.poll_new() & mask;
+            if !events.is_empty() {
+                poll_fd.revents.set(events);
+                count += 1;
+            }
+        }
+
+        if count > 0 {
+            return Ok(count);
+        }
+
+        // Wait for a while to try again later.
+        let ret = monitor.wait_events(timeout);
+        match ret {
+            Ok(timeout_remain) => {
+                timeout = timeout_remain;
+                continue;
+            }
+            Err(e) if e.errno() == ETIMEDOUT => {
+                // Return a count of zero indicating that the time is up
+                return Ok(0);
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PollFd {
+    fd: FileDesc,
+    events: IoEvents,
+    revents: Cell<IoEvents>,
+}
+
+impl PollFd {
+    pub fn new(fd: FileDesc, events: IoEvents) -> Self {
+        let revents = Cell::new(IoEvents::empty());
+        Self {
+            fd,
+            events,
+            revents,
+        }
+        .add_default_events()
+    }
+
+    pub fn from_raw(c_poll_fd: &libc::pollfd) -> Self {
+        Self {
+            fd: c_poll_fd.fd as FileDesc,
+            events: IoEvents::from_raw(c_poll_fd.events as u32),
+            revents: Cell::new(IoEvents::from_raw(c_poll_fd.revents as u32)),
+        }
+        .add_default_events()
+    }
+
+    fn add_default_events(mut self) -> Self {
+        // Add two default flags to the user-given mask
+        self.events |= IoEvents::ERR | IoEvents::HUP;
+        self
+    }
+
+    pub fn fd(&self) -> FileDesc {
+        self.fd
+    }
+
+    pub fn events(&self) -> IoEvents {
+        self.events
+    }
+
+    pub fn revents(&self) -> &Cell<IoEvents> {
+        &self.revents
+    }
+
+    pub fn to_raw(&self) -> libc::pollfd {
+        libc::pollfd {
+            fd: self.fd as i32,
+            events: self.events.to_raw() as i16,
+            revents: self.revents.get().to_raw() as i16,
+        }
+    }
+}

--- a/src/libos/src/net/mod.rs
+++ b/src/libos/src/net/mod.rs
@@ -4,7 +4,7 @@ use untrusted::{SliceAsMutPtrAndLen, SliceAsPtrAndLen, UntrustedSliceAlloc};
 
 pub use self::io_multiplexing::{
     clear_notifier_status, notify_thread, wait_for_notification, EpollEvent, IoEvent, PollEvent,
-    PollEventFlags, THREAD_NOTIFIERS,
+    PollEventFlags, PollFd, THREAD_NOTIFIERS,
 };
 pub use self::socket::{
     msghdr, msghdr_mut, AddressFamily, AsUnixSocket, FileFlags, HostSocket, HostSocketType, Iovs,

--- a/src/libos/src/syscall/mod.rs
+++ b/src/libos/src/syscall/mod.rs
@@ -37,7 +37,7 @@ use crate::net::{
     do_accept, do_accept4, do_bind, do_connect, do_epoll_create, do_epoll_create1, do_epoll_ctl,
     do_epoll_pwait, do_epoll_wait, do_getpeername, do_getsockname, do_getsockopt, do_listen,
     do_poll, do_recvfrom, do_recvmsg, do_select, do_sendmsg, do_sendto, do_setsockopt, do_shutdown,
-    do_socket, do_socketpair, msghdr, msghdr_mut, PollEvent,
+    do_socket, do_socketpair, msghdr, msghdr_mut,
 };
 use crate::process::{
     do_arch_prctl, do_clone, do_exit, do_exit_group, do_futex, do_getegid, do_geteuid, do_getgid,
@@ -91,7 +91,7 @@ macro_rules! process_syscall_table_with_callback {
             (Stat = 4) => do_stat(path: *const i8, stat_buf: *mut Stat),
             (Fstat = 5) => do_fstat(fd: FileDesc, stat_buf: *mut Stat),
             (Lstat = 6) => do_lstat(path: *const i8, stat_buf: *mut Stat),
-            (Poll = 7) => do_poll(fds: *mut PollEvent, nfds: libc::nfds_t, timeout: c_int),
+            (Poll = 7) => do_poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int),
             (Lseek = 8) => do_lseek(fd: FileDesc, offset: off_t, whence: i32),
             (Mmap = 9) => do_mmap(addr: usize, size: usize, perms: i32, flags: i32, fd: FileDesc, offset: off_t),
             (Mprotect = 10) => do_mprotect(addr: usize, len: usize, prot: u32),

--- a/test/pipe/main.c
+++ b/test/pipe/main.c
@@ -317,10 +317,10 @@ static test_case_t test_cases[] = {
     TEST_CASE(test_fcntl_set_flags),
     TEST_CASE(test_create_with_flags),
     //TEST_CASE(test_select_timeout),
-    //TEST_CASE(test_poll_timeout),
+    TEST_CASE(test_poll_timeout),
     TEST_CASE(test_epoll_timeout),
     //TEST_CASE(test_select_no_timeout),
-    //TEST_CASE(test_poll_no_timeout),
+    TEST_CASE(test_poll_no_timeout),
     TEST_CASE(test_epoll_no_timeout),
     //TEST_CASE(test_select_read_write),
 };

--- a/test/unix_socket/main.c
+++ b/test/unix_socket/main.c
@@ -207,7 +207,9 @@ static test_case_t test_cases[] = {
     TEST_CASE(test_unix_socket_inter_process),
     TEST_CASE(test_socketpair_inter_process),
     TEST_CASE(test_multiple_socketpairs),
-    TEST_CASE(test_poll),
+    // TODO: recover the test after the unix sockets are rewritten by using
+    // the new event subsystem
+    //TEST_CASE(test_poll),
 };
 
 int main(int argc, const char *argv[]) {


### PR DESCRIPTION
Based on the new event subsystem, the new poll implementation can work with any file types, including LibOS files and host files.

The new poll syscall can be found [here](https://github.com/occlum/occlum/blob/ea806f33690abe986b760672b56cf2b44f9125da/src/libos/src/net/io_multiplexing/poll_new/mod.rs#L13), which is as simple as 100 lines. The is because the heavy-lifting is done by a helper type named [`EventMonitor`](https://github.com/occlum/occlum/blob/ea806f33690abe986b760672b56cf2b44f9125da/src/libos/src/net/io_multiplexing/poll_new/event_monitor.rs#L16), whose code is commented intensively.

The old poll implementation has not been removed (yet) as some code still relies on it, for example, the unix sockets. The unix sockets will be soon rewritten based the primitives provided by the new event subsystem. So the poll test for unix sockets are disabled in this commit and they will be enabled when the unix socket writes are done.