### PR TITLE
Fix two cpuid bugs

### DIFF
--- a/src/libos/src/exception/cpuid.rs
+++ b/src/libos/src/exception/cpuid.rs
@@ -81,7 +81,7 @@ impl CpuIdCache {
                         // EDX Bit 00: Reserved.
                         //     Bit 01: Supports L3 Cache Intel RDT Monitoring if 1.
                         //     Bits 31 - 02: Reserved.
-                        0xF => cpuid_result.edx & 0x0000_0002 >> 1,
+                        0xF => (cpuid_result.edx & 0x0000_0002) >> 1,
                         // Reports valid ResID starting at bit position 1 of EBX.
                         // EBX Bit 00: Reserved.
                         //     Bit 01: Supports L3 Cache Allocation Technology if 1.

--- a/test/cpuid/main.c
+++ b/test/cpuid/main.c
@@ -35,8 +35,8 @@ static bool is_cpuidinfo_equal(int leaf, t_cpuid_t *cpu, t_cpuid_t *cpu_sgx) {
                 (cpu->ecx == cpu_sgx->ecx) &&
                 (cpu->edx == cpu_sgx->edx));
     }
-    /* Leaf 0BH CPUID.EDX is related with logical processor. */
-    if (leaf == 0xB) {
+    /* Leaf 0BH and 06H CPUID.EDX is related with logical processor. */
+    if (leaf == 0xB || leaf == 0x6) {
         return ((cpu->eax == cpu_sgx->eax) &&
                 (cpu->ebx == cpu_sgx->ebx) &&
                 (cpu->ecx == cpu_sgx->ecx));


### PR DESCRIPTION
1.  `>>` has higher precedence than `&`. Use parentheses to conduct `&` first;
2. In the latest Intel software developer's manual, cpuid leaf 06H EDX
is related to the logical processor.