### PR TITLE
Unregister a file from epoll files when the file is closed

### DIFF
--- a/src/libos/src/fs/file_ops/close.rs
+++ b/src/libos/src/fs/file_ops/close.rs
@@ -4,6 +4,12 @@ pub fn do_close(fd: FileDesc) -> Result<()> {
     debug!("close: fd: {}", fd);
     let current = current!();
     let mut files = current.files().lock().unwrap();
-    files.del(fd)?;
+    let file = files.del(fd)?;
+    // Deadlock note: EpollFile's drop method needs to access file table. So
+    // if the drop method is invoked inside the del method, then there will be
+    // a deadlock.
+    // TODO: make FileTable a struct of internal mutability to avoid deadlock.
+    drop(files);
+    drop(file);
     Ok(())
 }

--- a/src/libos/src/fs/mod.rs
+++ b/src/libos/src/fs/mod.rs
@@ -18,7 +18,7 @@ pub use self::file_ops::{
     occlum_ocall_ioctl, AccessMode, BuiltinIoctlNum, CreationFlags, FileMode, Flock, FlockType,
     IfConf, IoctlCmd, Stat, StatusFlags, StructuredIoctlArgType, StructuredIoctlNum,
 };
-pub use self::file_table::{FileDesc, FileTable};
+pub use self::file_table::{FileDesc, FileTable, FileTableEvent, FileTableNotifier};
 pub use self::fs_view::FsView;
 pub use self::host_fd::HostFd;
 pub use self::inode_file::{AsINodeFile, INodeExt, INodeFile};


### PR DESCRIPTION
Usually, files are unregistered from an epoll file via the `EPOLL_CTL_DEL` command explicitly. But for the sake of users' convenience, Linux supports unregistering a file automatically from the epoll files that monitor the file when the file is closed. This commit adds this capability.