### PR TITLE
Fix Python test malloc failure on SGX machine

### DIFF
--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -396,3 +396,6 @@ jobs:
 
     - name: Run python support test
       run: docker exec python_support_test bash -c "cd /root/occlum/demos/python; SGX_MODE=SIM ./run_python_on_occlum.sh"
+
+    - name: Check result
+      run: docker exec python_support_test bash -c "cd /root/occlum/demos/python/occlum_instance; cat smvlight.dat"

--- a/.github/workflows/hw_mode_test.yml
+++ b/.github/workflows/hw_mode_test.yml
@@ -297,6 +297,9 @@ jobs:
     - name: Run python support test
       run: docker exec python_support_test bash -c "cd /root/occlum/demos/python; ./run_python_on_occlum.sh"
 
+    - name: Check result
+      run: docker exec python_support_test bash -c "cd /root/occlum/demos/python/occlum_instance; cat smvlight.dat"
+
     - name: Clean the environment
       run: docker stop python_support_test
 

--- a/demos/python/run_python_on_occlum.sh
+++ b/demos/python/run_python_on_occlum.sh
@@ -35,7 +35,7 @@ if [ ! -d "image/lib/python3.7" ];then
     cp -rf ../dataset image
     cp -f ../demo.py image
     new_json="$(jq '.resource_limits.user_space_size = "320MB" |
-                    .resource_limits.kernel_space_heap_size = "192MB" |
+                    .resource_limits.kernel_space_heap_size = "256MB" |
                     .process.default_mmap_size = "256MB"' Occlum.json)" && \
     echo "${new_json}" > Occlum.json
     occlum build


### PR DESCRIPTION
Using tcmalloc could consume more heap. Enlarging kernel heap allocation can fix this.

Also, print results for Python test.