### PR TITLE
Use HostFd to manage the lifetime of host OS resources

### DIFF
--- a/src/libos/src/fs/event_file.rs
+++ b/src/libos/src/fs/event_file.rs
@@ -49,13 +49,6 @@ extern "C" {
     fn occlum_ocall_eventfd(ret: *mut i32, init_val: u32, flags: i32) -> sgx_status_t;
 }
 
-impl Drop for EventFile {
-    fn drop(&mut self) {
-        let ret = unsafe { libc::ocall::close(self.host_fd.to_raw() as i32) };
-        assert!(ret == 0);
-    }
-}
-
 impl File for EventFile {
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         let (buf_ptr, buf_len) = buf.as_mut().as_mut_ptr_and_len();

--- a/src/libos/src/net/io_multiplexing/epoll/host_file_epoller.rs
+++ b/src/libos/src/net/io_multiplexing/epoll/host_file_epoller.rs
@@ -180,11 +180,3 @@ impl HostFileEpoller {
         &self.host_epoll_fd
     }
 }
-
-impl Drop for HostFileEpoller {
-    fn drop(&mut self) {
-        unsafe {
-            libc::ocall::close(self.host_epoll_fd.to_raw() as i32);
-        }
-    }
-}

--- a/src/libos/src/net/socket/host_socket/mod.rs
+++ b/src/libos/src/net/socket/host_socket/mod.rs
@@ -134,13 +134,6 @@ impl HostSocket {
     }
 }
 
-impl Drop for HostSocket {
-    fn drop(&mut self) {
-        let ret = unsafe { libc::ocall::close(self.host_fd.to_raw() as i32) };
-        assert!(ret == 0);
-    }
-}
-
 pub trait HostSocketType {
     fn as_host_socket(&self) -> Result<&HostSocket>;
 }


### PR DESCRIPTION
This PR should be able fix issue #231 although I haven't been able to reproduce the bug reported in the issue. With that said, this PR fixes a race condition (in very rare cases) that causes `HostFd::new` to panic.

By the way, I have repeated the server and eventfd tests, which are supposed to be able to trigger the bug according to #231, for 500 times. No panics occur. So I think the bug should have been fixed.