### PR TITLE
Check resource leak when all processes exit

### DIFF
--- a/src/libos/Cargo.lock
+++ b/src/libos/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "bitflags",
  "bitvec",
  "derive_builder",
+ "inventory",
  "lazy_static",
  "log",
  "rcore-fs",
@@ -103,6 +104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -202,6 +213,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "hashbrown_tstd"
 version = "0.9.0"
 
@@ -210,6 +232,28 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "inventory"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedd49de24d8c263613701406611410687148ae8c37cd6452650b250f753a0dd"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddead8880bc50f57fcd3b5869a7f6ff92570bb4e8f6870c22e2483272f2256da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "itoa"

--- a/src/libos/Cargo.toml
+++ b/src/libos/Cargo.toml
@@ -23,6 +23,7 @@ rcore-fs-mountfs = { path = "../../deps/sefs/rcore-fs-mountfs" }
 rcore-fs-unionfs = { path = "../../deps/sefs/rcore-fs-unionfs" }
 serde = { path = "../../deps/serde-sgx/serde", features = ["derive"] }
 serde_json = { path = "../../deps/serde-json-sgx" }
+inventory = { version = "0.1.9" }
 
 [patch.'https://github.com/apache/teaclave-sgx-sdk.git']
 sgx_tstd = { path = "../../deps/rust-sgx-sdk/sgx_tstd" }

--- a/src/libos/src/net/io_multiplexing/io_event.rs
+++ b/src/libos/src/net/io_multiplexing/io_event.rs
@@ -1,9 +1,20 @@
 use super::*;
 use crate::fs::EventFile;
+use crate::util::resource_checker::StaticResourceChecker;
 
 lazy_static! {
     pub static ref THREAD_NOTIFIERS: SgxMutex<HashMap<pid_t, EventFile>> =
         SgxMutex::new(HashMap::new());
+}
+
+inventory::submit! {
+    StaticResourceChecker::new(||
+        if THREAD_NOTIFIERS.lock().unwrap().is_empty(){
+            false
+        } else {
+            error!("THREAD_NOTIFIERS is not empty.");
+            true
+        })
 }
 
 #[derive(Debug)]

--- a/src/libos/src/util/mod.rs
+++ b/src/libos/src/util/mod.rs
@@ -4,6 +4,7 @@ pub mod dirty;
 pub mod log;
 pub mod mem_util;
 pub mod mpx_util;
+pub mod resource_checker;
 pub mod ring_buf;
 pub mod sgx;
 pub mod sync;

--- a/src/libos/src/util/resource_checker.rs
+++ b/src/libos/src/util/resource_checker.rs
@@ -1,0 +1,13 @@
+inventory::collect!(StaticResourceChecker);
+pub struct StaticResourceChecker {
+    is_leak: fn() -> bool,
+}
+
+impl StaticResourceChecker {
+    pub fn new(is_leak: fn() -> bool) -> Self {
+        Self { is_leak }
+    }
+    pub fn is_leak(&self) -> fn() -> bool {
+        self.is_leak
+    }
+}

--- a/src/pal/src/pal_enclave.c
+++ b/src/pal/src/pal_enclave.c
@@ -129,7 +129,11 @@ int pal_init_enclave(const char *instance_dir) {
     return 0;
 }
 
+#define SIGKILL 9
 int pal_destroy_enclave(void) {
+    /* force kill all the process, if any is running. */
+    int ret = occlum_pal_kill(-1, SIGKILL);
+
 // FIXME: Due to lack of support for enclave interrupt in simulation mode, some programs
 // come across the problem that it can't exit when running in simulation mode. We have to
 // fallback to the old way to exit brutely in simulation mode.
@@ -138,7 +142,7 @@ int pal_destroy_enclave(void) {
     global_eid = SGX_INVALID_ENCLAVE_ID;
 #endif
 
-    return 0;
+    return ret;
 }
 
 sgx_enclave_id_t pal_get_enclave_id(void) {


### PR DESCRIPTION
Detect resource leaks when all the processes exit.
The current simulation mode has some limitations, so we could see error messages in simulation mode tests.