### PR TITLE
Fix the UDS path is too long issue

### DIFF
--- a/src/exec/src/lib.rs
+++ b/src/exec/src/lib.rs
@@ -13,7 +13,6 @@ pub mod occlum_exec_grpc;
 
 pub mod server;
 
-pub const DEFAULT_SERVER_FILE: &'static str = "occlum_exec_server";
-pub const DEFAULT_CLIENT_FILE: &'static str = "occlum_exec_client";
-pub const DEFAULT_SOCK_FILE: &'static str = "occlum_exec.sock";
+pub const DEFAULT_SERVER_FILE: &'static str = "build/bin/occlum_exec_server";
+pub const DEFAULT_SOCK_FILE: &'static str = "run/occlum_exec.sock";
 pub const DEFAULT_SERVER_TIMER: u32 = 3;


### PR DESCRIPTION
The UDS path length should less than sun_path length, it
is too short in some cases. So use a file under /tmp folder
as the UDS path.