### PR TITLE
Enlarge the kernel heap size in make test

### DIFF
--- a/test/Occlum.json
+++ b/test/Occlum.json
@@ -1,6 +1,6 @@
 {
     "resource_limits": {
-        "kernel_space_heap_size": "32MB",
+        "kernel_space_heap_size": "40MB",
         "kernel_space_stack_size": "1MB",
         "user_space_size": "128MB",
         "max_num_of_threads": 32


### PR DESCRIPTION
The CI test randomly failed for the lack of heap.