### PR TITLE
Fix the sched test when available cpu is less than online cpu

### DIFF
--- a/test/sched/main.c
+++ b/test/sched/main.c
@@ -54,8 +54,8 @@ static int test_sched_getaffinity_with_self_pid() {
     if (CPU_COUNT(&mask) <= 0) {
         THROW_ERROR("failed to get cpuset mask");
     }
-    if (sysconf(_SC_NPROCESSORS_ONLN) != CPU_COUNT(&mask)) {
-        THROW_ERROR("cpuset num wrong");
+    if (sysconf(_SC_NPROCESSORS_ONLN) < CPU_COUNT(&mask)) {
+        THROW_ERROR("cpuset num must be less or equal to _SC_NPROCESSORS_ONLN");
     }
     return 0;
 }
@@ -166,7 +166,7 @@ static int test_sched_xetaffinity_children_inheritance() {
     return 0;
 }
 
-#define CPU_SET_SIZE_LIMIT (1024)
+#define CPU_SET_SIZE_LIMIT (128)
 
 static int test_sched_getaffinity_via_explicit_syscall() {
     unsigned char buf[CPU_SET_SIZE_LIMIT] = { 0 };


### PR DESCRIPTION
The number of available cpu is fetched from `sched_getaffinity()`, it may be less than all online cpus, we should not assume that the number is equal to all online cpus.