### PR TITLE
Remove the flags argument handling in fchmodat syscall

### DIFF
--- a/src/libos/src/fs/file_ops/chmod.rs
+++ b/src/libos/src/fs/file_ops/chmod.rs
@@ -55,27 +55,14 @@ impl FileMode {
     }
 }
 
-bitflags! {
-    pub struct ChmodFlags: i32 {
-        const AT_SYMLINK_NOFOLLOW = 0x100;
-    }
-}
-
-pub fn do_fchmodat(fs_path: &FsPath, mode: FileMode, flags: ChmodFlags) -> Result<()> {
-    debug!(
-        "fchmodat: fs_path: {:?}, mode: {:#o}, flags: {:?}",
-        fs_path, mode, flags
-    );
+pub fn do_fchmodat(fs_path: &FsPath, mode: FileMode) -> Result<()> {
+    debug!("fchmodat: fs_path: {:?}, mode: {:#o}", fs_path, mode);
 
     let inode = {
         let path = fs_path.to_abs_path()?;
         let current = current!();
         let fs = current.fs().lock().unwrap();
-        if flags.contains(ChmodFlags::AT_SYMLINK_NOFOLLOW) {
-            fs.lookup_inode_no_follow(&path)?
-        } else {
-            fs.lookup_inode(&path)?
-        }
+        fs.lookup_inode(&path)?
     };
     let mut info = inode.metadata()?;
     info.mode = mode.bits();

--- a/src/libos/src/fs/file_ops/mod.rs
+++ b/src/libos/src/fs/file_ops/mod.rs
@@ -3,7 +3,7 @@ use super::*;
 use process::Process;
 
 pub use self::access::{do_faccessat, AccessibilityCheckFlags, AccessibilityCheckMode};
-pub use self::chmod::{do_fchmod, do_fchmodat, ChmodFlags, FileMode};
+pub use self::chmod::{do_fchmod, do_fchmodat, FileMode};
 pub use self::chown::{do_fchown, do_fchownat, ChownFlags};
 pub use self::close::do_close;
 pub use self::dirent::{do_getdents, do_getdents64};

--- a/src/libos/src/fs/syscalls.rs
+++ b/src/libos/src/fs/syscalls.rs
@@ -1,8 +1,8 @@
 use super::event_file::EventCreationFlags;
 use super::file_ops;
 use super::file_ops::{
-    AccessibilityCheckFlags, AccessibilityCheckMode, ChmodFlags, ChownFlags, FcntlCmd, FsPath,
-    LinkFlags, StatFlags, UnlinkFlags, AT_FDCWD,
+    AccessibilityCheckFlags, AccessibilityCheckMode, ChownFlags, FcntlCmd, FsPath, LinkFlags,
+    StatFlags, UnlinkFlags, AT_FDCWD,
 };
 use super::fs_ops;
 use super::*;
@@ -433,7 +433,7 @@ pub fn do_symlinkat(target: *const i8, new_dirfd: i32, link_path: *const i8) -> 
 }
 
 pub fn do_chmod(path: *const i8, mode: u16) -> Result<isize> {
-    self::do_fchmodat(AT_FDCWD, path, mode, 0)
+    self::do_fchmodat(AT_FDCWD, path, mode)
 }
 
 pub fn do_fchmod(fd: FileDesc, mode: u16) -> Result<isize> {
@@ -442,14 +442,13 @@ pub fn do_fchmod(fd: FileDesc, mode: u16) -> Result<isize> {
     Ok(0)
 }
 
-pub fn do_fchmodat(dirfd: i32, path: *const i8, mode: u16, flags: i32) -> Result<isize> {
+pub fn do_fchmodat(dirfd: i32, path: *const i8, mode: u16) -> Result<isize> {
     let path = from_user::clone_cstring_safely(path)?
         .to_string_lossy()
         .into_owned();
     let mode = FileMode::from_bits_truncate(mode);
     let fs_path = FsPath::new(&path, dirfd, false)?;
-    let flags = ChmodFlags::from_bits(flags).ok_or_else(|| errno!(EINVAL, "invalid flags"))?;
-    file_ops::do_fchmodat(&fs_path, mode, flags)?;
+    file_ops::do_fchmodat(&fs_path, mode)?;
     Ok(0)
 }
 

--- a/src/libos/src/syscall/mod.rs
+++ b/src/libos/src/syscall/mod.rs
@@ -352,7 +352,7 @@ macro_rules! process_syscall_table_with_callback {
             (Linkat = 265) => do_linkat(olddirfd: i32, oldpath: *const i8, newdirfd: i32, newpath: *const i8, flags: i32),
             (Symlinkat = 266) => do_symlinkat(target: *const i8, new_dirfd: i32, link_path: *const i8),
             (Readlinkat = 267) => do_readlinkat(dirfd: i32, path: *const i8, buf: *mut u8, size: usize),
-            (Fchmodat = 268) => do_fchmodat(dirfd: i32, path: *const i8, mode: u16, flags: i32),
+            (Fchmodat = 268) => do_fchmodat(dirfd: i32, path: *const i8, mode: u16),
             (Faccessat = 269) => do_faccessat(dirfd: i32, path: *const i8, mode: u32, flags: u32),
             (Pselect6 = 270) => handle_unsupported(),
             (Ppoll = 271) => handle_unsupported(),


### PR DESCRIPTION
The flags argument of fchmodat syscall is handled by the wrapper function in libc already, so Occlum does not need to accept this argument.