### PR TITLE
Fix gRPC and OpenVINO CI image demo location

### DIFF
--- a/tools/docker/ci/Dockerfile.grpc
+++ b/tools/docker/ci/Dockerfile.grpc
@@ -3,7 +3,8 @@ FROM occlum/occlum:$OCCLUM_VERSION-ubuntu18.04 as base
 LABEL maintainer="Chunyang Hui <sanqian.hcy@antgroup.com>"
 
 WORKDIR /root
-RUN git clone https://github.com/occlum/occlum.git && \
+RUN rm -rf /root/demos && \
+    git clone https://github.com/occlum/occlum.git && \
     cp -r occlum/demos /root/demos && \
     rm -rf /root/occlum
 

--- a/tools/docker/ci/Dockerfile.openvino
+++ b/tools/docker/ci/Dockerfile.openvino
@@ -3,7 +3,8 @@ FROM occlum/occlum:$OCCLUM_VERSION-ubuntu18.04 as base
 LABEL maintainer="Chunyang Hui <sanqian.hcy@antgroup.com>"
 
 WORKDIR /root
-RUN git clone https://github.com/occlum/occlum.git && \
+RUN rm -rf /root/demos && \
+    git clone https://github.com/occlum/occlum.git && \
     cp -r occlum/demos /root/demos && \
     rm -rf /root/occlum
 


### PR DESCRIPTION
The demo dir location in the CI image is wrong. This commit fixed this.