### PR TITLE
Add errno info when return error in make test

### DIFF
--- a/test/include/test.h
+++ b/test/include/test.h
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <unistd.h>
+#include <errno.h>
+#include <string.h>
 
 #define _STR(x)             #x
 #define STR(x)              _STR(x)
@@ -21,8 +23,8 @@ typedef struct {
 #define TEST_CASE(name)     { STR(name), name }
 
 #define THROW_ERROR(fmt, ...)   do { \
-    printf("\t\tERROR:" fmt " in func %s at line %d of file %s\n", \
-    ##__VA_ARGS__, __func__, __LINE__, __FILE__); \
+    printf("\t\tERROR:" fmt " in func %s at line %d of file %s with errno %d: %s\n", \
+    ##__VA_ARGS__, __func__, __LINE__, __FILE__, errno, strerror(errno)); \
     return -1; \
 } while (0)
 


### PR DESCRIPTION
When encountering an error in make test and THROW_ERROR is called, output will be like this:

`ERROR:spawn process error in func test_sched_xetaffinity_with_child_pid at line 100 of file main.c with errno 12: Out of memory`