### PR TITLE
Fix docker image for SGX1 HW

### DIFF
--- a/tools/docker/Dockerfile.centos8.2
+++ b/tools/docker/Dockerfile.centos8.2
@@ -123,6 +123,8 @@ RUN echo "ca_directory=/etc/ssl/certs" >> /etc/wgetrc && \
     libsgx-uae-service*.rpm \
     libsgx-epid*.rpm \
     libsgx-launch*.rpm \
+    libsgx-ae-le-*.rpm \
+    libsgx-aesm-launch-plugin-*.rpm \
     sgx-aesm-service*.rpm && \
     rm -rf /tmp/sgx_rpm_local_repo
 

--- a/tools/docker/start_aesm.sh
+++ b/tools/docker/start_aesm.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Start AESM service required by Intel SGX SDK if it is not running
 if ! pgrep "aesm_service" > /dev/null ; then
-    LD_LIBRARY_PATH="/opt/intel/sgx-aesm-service/aesm:$LD_LIBRARY_PATH" /opt/intel/sgx-aesm-service/aesm/aesm_service --no-daemon
+    LD_LIBRARY_PATH="/opt/intel/sgx-aesm-service/aesm:$LD_LIBRARY_PATH" nohup /opt/intel/sgx-aesm-service/aesm/aesm_service --no-daemon >/dev/null 2>&1 &
 fi
+


### PR DESCRIPTION
1. Run AESM at background
2. CentOS docker image missed aesm-launch-plugin