### PR TITLE
Fix installer for new release

### DIFF
--- a/.github/workflows/package_repo_setup_and_test.yml
+++ b/.github/workflows/package_repo_setup_and_test.yml
@@ -9,6 +9,14 @@ jobs:
     env:
      TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
+    # This step is added to get more free space
+    - name: Clean virtual environment
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
     - name: Checkout occlum src code
       uses: actions/checkout@v2
       with:
@@ -44,6 +52,11 @@ jobs:
             aptly publish repo occlum-deb-repo; tree /root/.aptly/public;
             cd /root/workspace/occlum-package-repos; rm -rf debian; cp -r /root/.aptly/public /root/workspace/occlum-package-repos/debian;
             cp /root/public.key /root/workspace/occlum-package-repos/debian'
+
+    - name: Clean ubuntu container and image
+      run: |
+          docker rm -f ubuntu
+          docker rmi -f occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
 
     - name: Create centos container
       run: docker run -itd --name=centos -v $GITHUB_WORKSPACE:/root/workspace occlum/occlum:${{ env.OCCLUM_VERSION }}-centos8.2

--- a/tools/installer/rpm/occlum-filelist
+++ b/tools/installer/rpm/occlum-filelist
@@ -2,6 +2,7 @@
 /opt/occlum/build/bin/occlum-protect-integrity
 /opt/occlum/build/bin/sefs-cli
 /opt/occlum/build/bin/sefs-cli_sim
+/opt/occlum/build/bin/init
 /opt/occlum/build/lib/libocclum-pal_sim.so*
 /opt/occlum/build/lib/libocclum-libos.so*
 /opt/occlum/build/lib/libocclum-libos_sim.so*

--- a/tools/installer/rpm/occlum.spec
+++ b/tools/installer/rpm/occlum.spec
@@ -1,8 +1,9 @@
 %define centos_base_release 1
-
 %define _unpackaged_files_terminate_build 0
 %define sgxsdk_install_dir /opt/intel
 
+# Ignore missing build id error (generated when packaging "init" binary)
+%global _missing_build_ids_terminate_build 0
 # Remove checking for python shebang error in sgx-gdb
 %undefine __brp_mangle_shebangs
 


### PR DESCRIPTION
This commit fixed three errors:
(1) Fix Github action virtual environment out of free disk space
(2) Add "init" binary which is recently added for the encrypted image
(3) Bypass "Missing build-id" error when RPM packaging

This change has been verified in my local repository.