### PR TITLE
Export error message when parsing Elf header

### DIFF
--- a/src/libos/src/process/do_spawn/exec_loader.rs
+++ b/src/libos/src/process/do_spawn/exec_loader.rs
@@ -98,10 +98,12 @@ pub fn load_file_hdr_to_vec(
         .read_elf64_lazy_as_vec()
         .map_err(|e| errno!(e.errno(), "failed to read the file"))?;
 
-    if let Ok(elf_header) = ElfFile::parse_elf_hdr(&inode, &mut file_buf) {
+    let elf_header = ElfFile::parse_elf_hdr(&inode, &mut file_buf);
+    if let Ok(elf_header) = elf_header {
         Ok((inode, file_buf, Some(elf_header)))
     } else {
-        // this file is not ELF format
+        // this file is not ELF format or there is something wrong when parsing
+        warn!("parse elf header error = {}", elf_header.err().unwrap());
         Ok((inode, file_buf, None))
     }
 }


### PR DESCRIPTION
Previously, error messages when `parse_elf_hdr ` are not exported.

Running an elf file without -fPIE compiling option will look like this:
![截屏2021-03-22 下午4 45 32](https://user-images.githubusercontent.com/13930406/111963023-06933800-8b2e-11eb-8a5b-69c9fe923aff.png)
