### PR TITLE
Fix occlum build "-f" option mistakenly rebuild other targets

### DIFF
--- a/tools/occlum
+++ b/tools/occlum
@@ -247,7 +247,7 @@ cmd_build() {
         --sgx-mode)     [[ -n "$2" && "$2" != "HW" ]] && export SGX_MODE=SIM ; shift 2 || exit_error "empty sgx mode";;
         --image-key)    [ -n "$2" ] && SECURE_IMAGE_KEY=$2 ; shift 2 || exit_error "empty secure image key path"   ;;
         --buildin-image-key)  BUILDIN_IMAGE_KEY=true ; shift ;;
-        --force | -f)   MAKE_OPTION="--always-make" ; shift ;;
+        --force | -f)   MAKE_OPTION="clean" ; shift ;;
         *) exit_error "Unknown option: $1"                                                                      ;;
         esac
     done
@@ -272,22 +272,25 @@ cmd_build() {
     # If sgx mode is changed, build thoroughly again
     if [[ -n $SGX_MODE && "$SGX_MODE" != "HW" ]]; then
         if [ "$(cat $instance_dir/.sgx_mode 2>/dev/null)" != "SIM" ]; then
-            MAKE_OPTION="--always-make"
+            MAKE_OPTION="clean"
         fi
     else
         #HW mode
         if [ "$(cat $instance_dir/.sgx_mode 2>/dev/null)" != "HW" ]; then
-            MAKE_OPTION="--always-make"
+            MAKE_OPTION="clean"
         fi
     fi
 
     rm -rf "$instance_dir/run"
-
+    if [[ -n $MAKE_OPTION ]]; then
+        occlum_dir=$occlum_dir instance_dir=$instance_dir \
+        make -f $build_makefile $MAKE_OPTION
+    fi
     occlum_dir=$occlum_dir instance_dir=$instance_dir pal_lib=$pal_lib major_ver=$major_ver \
     occlum_version=$occlum_version libos_lib=$libos_lib \
     ENCLAVE_SIGN_KEY=$ENCLAVE_SIGN_KEY ENCLAVE_SIGN_TOOL=$ENCLAVE_SIGN_TOOL \
     SECURE_IMAGE_KEY=$SECURE_IMAGE_KEY BUILDIN_IMAGE_KEY=$BUILDIN_IMAGE_KEY \
-    make -f $build_makefile $MAKE_OPTION
+    make -f $build_makefile --no-builtin-rules
 
     cd "$instance_dir"
     echo "built" > $status_file

--- a/tools/occlum_build.mk
+++ b/tools/occlum_build.mk
@@ -43,7 +43,7 @@ define get_occlum_user_conf_file_mac
 		"$(occlum_dir)/build/bin/occlum-protect-integrity" show-mac "$(instance_dir)/build/Occlum.json.protected"
 endef
 
-.PHONY : all
+.PHONY : all clean
 
 ALL_TARGETS := $(SIGNED_ENCLAVE) $(BIN_LINKS) $(LIB_LINKS)
 
@@ -142,3 +142,6 @@ $(SECURE_IMAGE): $(IMAGE) $(IMAGE_DIRS) $(IMAGE_FILES) $(SEFS_CLI_SIM) $(SIGNED_
 			"$(instance_dir)/build/mount/__ROOT" \
 			"$(SECURE_IMAGE_MAC)"
 endif
+
+clean:
+	rm -rf $(instance_dir)/build


### PR DESCRIPTION
Remove "--always-remake" option and add "--no-builtin-rules" to avoid
mistakenly rebuild unwanted targets.

Fixed issue #430