### PR TITLE
Check AESM status with aesm socket file

### DIFF
--- a/tools/occlum
+++ b/tools/occlum
@@ -110,8 +110,14 @@ check_aesm_service() {
     if [ "$(cat $instance_dir/.sgx_mode 2>/dev/null)" != "HW" ]; then
         return
     fi
+
+    AESM_SOCKET_FILE=/var/run/aesmd/aesm.socket
     for i in $(seq 1 3); do
-        pgrep "aesm_service" > /dev/null && return || sleep 5
+        if [ -S "$AESM_SOCKET_FILE" ]; then
+            return
+        else
+            sleep 5
+        fi
     done
     echo "Error: AESM service is not started yet. Need to start it first"
     exit 1


### PR DESCRIPTION
Some user using host AESM, so Occlum should only check the socket file instead of the AESM process before running.