### PR TITLE
Fix readme doc for new dcap or in-tree kernel driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,23 @@ Step 1-3 are to be done on the host OS (Linux):
     ```bash
     docker run -it --device /dev/isgx occlum/occlum:[version]-ubuntu18.04
     ```
-    
-    For new DCAP driver:
+
+    For DCAP driver before v1.41:
     ```bash
-    docker run -it --device /dev/sgx/enclave occlum/occlum:[version]-ubuntu18.04
+    docker run -it --device /dev/sgx/enclave --device /dev/sgx/provision occlum/occlum:[version]-ubuntu18.04
+    ```
+
+    For DCAP driver since v1.41 or in-tree kernel driver:
+    ```bash
+    # Two methods:
+    # (1) Create softlinks on host
+    mkdir -p /dev/sgx
+    ln -sf ../sgx_enclave /dev/sgx/enclave
+    ln -sf ../sgx_provision /dev/sgx/provision
+    docker run -it --device /dev/sgx/enclave --device /dev/sgx/provision occlum/occlum:[version]-ubuntu18.04
+
+    # (2) Create the docker with privileged mode
+    docker run -it --privileged -v /dev/sgx_enclave:/dev/sgx/enclave -v /dev/sgx_provision:/dev/sgx/provision occlum/occlum:[version]-ubuntu18.04
     ```
 
 Step 4-5 are to be done on the guest OS running inside the Docker container:


### PR DESCRIPTION
Reference:
[1] https://github.com/intel/linux-sgx/blob/f1fcf9175d58d28bbee576438d9b68ecf93f5e4e/psw/urts/linux/edmm_utility.cpp#L89
[2] https://www.kernel.org/doc/html/v5.11/x86/sgx.html#enclave-build-functions