### PR TITLE
add support for OpenVINO 2021.3

### DIFF
--- a/.github/workflows/build_and_push_ci_image.yml
+++ b/.github/workflows/build_and_push_ci_image.yml
@@ -138,6 +138,44 @@ jobs:
         tags: occlumbackup/occlum:${{ github.event.inputs.tag }}-ubuntu18.04-openvino
 
 
+  Build_openvino2021_image:
+    runs-on: ubuntu-18.04
+    if: github.event.inputs.image_name == 'openvino2021'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get occlum version
+      run: echo "OCCLUM_VERSION=$(grep 'Version =' src/pal/include/occlum_version.h | awk '{print $4}')" >> $GITHUB_ENV;
+
+    # Because "Build and push" step `context` field can't be subdir,
+    # we need to copy files needed by dockerfile to root dir of the project
+    - name: Copy context for docker build
+      run: |
+        cp -r tools/docker .
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./tools/docker/ci/Dockerfile.openvino2021
+        platforms: linux/amd64
+        build-args: OCCLUM_VERSION=${{ env.OCCLUM_VERSION }}
+        push: true
+        tags: occlumbackup/occlum:${{ github.event.inputs.tag }}-ubuntu18.04-openvino2021
+
   Build_python_image:
     runs-on: ubuntu-18.04
     if: github.event.inputs.image_name == 'python'

--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -401,6 +401,26 @@ jobs:
       run: docker exec openvino_test bash -c "cd /root/demos/openvino && SGX_MODE=SIM ./run_benchmark_on_occlum.sh"
 
 
+  Openvino2021_test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Create container
+      run: docker run -itd --name=openvino2021_test -v $GITHUB_WORKSPACE:/root/occlum occlumbackup/occlum:latest-ubuntu18.04-openvino2021
+
+    - name: Build dependencies
+      run: docker exec openvino2021_test bash -c "cd /root/occlum; make submodule"
+
+    - name: Make install
+      run: docker exec openvino2021_test bash -c "source /opt/intel/sgxsdk/environment; cd /root/occlum; OCCLUM_RELEASE_BUILD=y make install"
+
+    - name: Run openVINO benchmark
+      run: docker exec openvino2021_test bash -c "cd /root/demos/openvino && SGX_MODE=SIM ./run_benchmark_on_occlum_2021.sh"
+
+
   # Python test also needs its own image because in Alpine environment, modules are built locally and consumes a lot of time.
   Python_musl_support_test:
     runs-on: ubuntu-18.04

--- a/demos/openvino/README.md
+++ b/demos/openvino/README.md
@@ -11,6 +11,10 @@ Step 2: Download OpenVINO and build the Inference Engine, it will also download 
 ```
 ./download_and_build_openvino.sh
 ```
+or using OpenVINO version 2021.3
+```
+./download_and_build_openvino_2021.sh
+```
 When completed, the resulting OpenVINO can be found in `openvino_src` directory. Threading Building Blocks (TBB) is used by default. To use OpenMP, add option `--threading OMP` when invoking the script above.
 
 Step 3: Download the example of OpenVINO models from [01.org](https://download.01.org/opencv/)
@@ -21,6 +25,10 @@ Step 3: Download the example of OpenVINO models from [01.org](https://download.0
 Step 4: Run OpenVINO Inference Engine benchmark app inside SGX enclave with Occlum
 ```
 ./run_benchmark_on_occlum.sh
+```
+or run sciprt for OpenVINO 2021.3
+```
+./run_benchmark_on_occlum_2021.sh
 ```
 
 Step 5 (Optional): Run OpenVINO Inference Engine benchmark app in Linux

--- a/demos/openvino/download_and_build_openvino_2021.sh
+++ b/demos/openvino/download_and_build_openvino_2021.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+PREFIX=/usr/local/occlum/x86_64-linux-musl
+THREADING=TBB
+set -e
+
+show_usage() {
+    echo
+    echo "Usage: $0 [--threading <TBB/OMP>]"
+    echo
+    exit 1
+}
+
+build_opencv() {
+    rm -rf deps/opencv && mkdir -p deps/opencv
+    pushd deps/opencv
+    git clone https://github.com/opencv/opencv .
+    git checkout tags/4.1.0 -b 4.1.0
+    mkdir build
+    cd build
+    cmake ../ \
+      -DCMAKE_BUILD_TYPE=RELEASE \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_C_COMPILER=occlum-gcc -DCMAKE_CXX_COMPILER=occlum-g++ \
+      -DENABLE_PRECOMPILED_HEADERS=OFF \
+      -DOPENCV_PC_FILE_NAME=opencv.pc \
+      -DOPENCV_GENERATE_PKGCONFIG=ON \
+      -DBUILD_opencv_java=OFF -DBUILD_JAVA_SUPPORT=OFF \
+      -DBUILD_opencv_python=OFF -DBUILD_PYTHON_SUPPORT=OFF \
+      -DBUILD_EXAMPLES=OFF -DWITH_FFMPEG=OFF \
+      -DWITH_QT=OFF -DWITH_CUDA=OFF
+    make -j
+    sudo make install
+    popd
+}
+
+# Build oneTBB,  OpenVINO_2021 need version 2020.3
+build_tbb() {
+    rm -rf deps/tbb_cmake && mkdir -p deps/tbb_cmake
+    pushd deps/tbb_cmake
+    git clone https://github.com/oneapi-src/oneTBB.git .
+    git checkout v2020.3
+    CXX=occlum-g++ CC=occlum-gcc make tbb -j4
+    find build/ -name libtbb* -exec cp {} $PREFIX/lib/ \;
+    popd
+}
+
+
+# Build OpenVINO
+build_openvino() {
+    rm -rf openvino_src && mkdir openvino_src
+    pushd openvino_src
+    git clone https://github.com/opencv/dldt .
+    git checkout 2021.3
+    git submodule init
+    git submodule update --recursive
+    mkdir build && cd build
+#   Substitute THREADING lib
+    cmake ../ \
+      -DTHREADING=$THREADING \
+      -DENABLE_MKL_DNN=ON \
+      -DENABLE_CLDNN=OFF \
+      -DENABLE_MYRIAD=OFF \
+      -DENABLE_GNA=OFF
+    [ "$THREADING" == "OMP" ] && rm -rf ../inference-engine/temp/omp/lib/* && cp $PREFIX/lib/libgomp.so ../inference-engine/temp/omp/lib/libiomp5.so
+    [ "$THREADING" == "TBB" ] && rm -rf ../inference-engine/temp/tbb/lib/* && cp $PREFIX/lib/libtbb.so.2 ../inference-engine/temp/tbb/lib
+    cd ../
+    rm -rf build && mkdir build && cd build
+#   Substitute OpenCV
+    export OpenCV_DIR=$PREFIX/lib/cmake/opencv4
+    cmake ../ \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_COMPILER=occlum-g++ -DCMAKE_CXX_FLAGS="-Wno-error=stringop-overflow=" \
+      -DCMAKE_C_COMPILER=occlum-gcc -DCMAKE_C_FLAGS="-Wno-error=stringop-overflow=" \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DTHREADING=$THREADING \
+      -DENABLE_MKL_DNN=ON \
+      -DENABLE_CLDNN=OFF \
+      -DENABLE_OPENCV=OFF \
+      -DENABLE_MYRIAD=OFF \
+      -DENABLE_GNA=OFF \
+      -DENABLE_VPU=OFF
+    make -j4
+    popd
+}
+
+while [ -n "$1" ]; do
+    case "$1" in
+    --threading)    [ -n "$2" ] && THREADING=$2 ; shift 2 || show_usage ;;
+    *)
+        show_usage
+    esac
+done
+
+# Tell CMake to search for packages in Occlum toolchain's directory only
+export PKG_CONFIG_LIBDIR=$PREFIX/lib
+
+if [ "$THREADING" == "TBB" ] ; then
+    echo "Build OpenVINO with TBB threading"
+    build_opencv
+    build_tbb
+    build_openvino
+elif [ "$THREADING" == "OMP" ] ; then
+    echo "Build OpenVINO with OpenMP threading"
+    build_opencv
+    build_openvino
+else
+    echo "Error: invalid threading: $THREADING"
+    show_usage
+fi

--- a/demos/openvino/run_benchmark_on_occlum_2021.sh
+++ b/demos/openvino/run_benchmark_on_occlum_2021.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+benchmark=benchmark_app
+inference_bin=openvino_src/bin/intel64/Release
+occlum_lib=/usr/local/occlum/x86_64-linux-musl/lib
+set -e
+
+# 1. Init Occlum Workspace
+rm -rf occlum_instance
+mkdir occlum_instance
+cd occlum_instance
+occlum init
+cpu_cc=`cat /proc/cpuinfo | grep processor | wc -l`
+new_json="$(jq '.resource_limits.user_space_size = "4GB" |
+                .resource_limits.kernel_space_heap_size = "128MB" |
+                .resource_limits.kernel_space_stack_size = "16MB" |
+                .resource_limits.max_num_of_threads = 128 |
+                .process.default_mmap_size = "1024MB" |
+                .process.default_stack_size = "8MB" |
+                .process.default_heap_size = "32MB" |
+                .metadata.debuggable = false ' Occlum.json)" && \
+echo "${new_json}" > Occlum.json
+
+# 2. Copy files into Occlum Workspace and Build
+cp ../$inference_bin/$benchmark image/bin
+cp ../$inference_bin/lib/libinference_engine.so image/lib
+cp ../$inference_bin/lib/libinference_engine_c_api.so image/lib
+cp ../$inference_bin/lib/libformat_reader.so image/lib
+cp ../$inference_bin/lib/libinference_engine_transformations.so image/lib
+cp ../$inference_bin/lib/libngraph.so image/lib
+cp ../$inference_bin/lib/libinference_engine_ir_v7_reader.so image/lib
+cp ../$inference_bin/lib/libinference_engine_ir_reader.so image/lib
+cp ../$inference_bin/lib/libMKLDNNPlugin.so image/lib
+cp ../$inference_bin/lib/libinference_engine_legacy.so image/lib
+cp ../$inference_bin/lib/libinference_engine_lp_transformations.so image/lib
+cp ../$inference_bin/lib/plugins.xml image/lib
+cp $occlum_lib/libopencv_imgcodecs.so.4.1 image/lib
+cp $occlum_lib/libopencv_imgproc.so.4.1 image/lib
+cp $occlum_lib/libopencv_core.so.4.1 image/lib
+cp $occlum_lib/libopencv_videoio.so.4.1 image/lib
+cp $occlum_lib/libz.so.1 image/lib
+[ -e $occlum_lib/libtbb.so.2 ] && cp $occlum_lib/libtbb.so.2 image/lib
+[ -e $occlum_lib/libtbbmalloc.so.2 ] && cp $occlum_lib/libtbbmalloc.so.2 image/lib
+mkdir image/model
+cp -r ../model/* image/model
+occlum build
+
+# 3. Run benchmark
+occlum run /bin/$benchmark -m /model/age-gender-recognition-retail-0013.xml

--- a/tools/docker/ci/Dockerfile.openvino2021
+++ b/tools/docker/ci/Dockerfile.openvino2021
@@ -1,0 +1,16 @@
+ARG OCCLUM_VERSION
+FROM occlum/occlum:$OCCLUM_VERSION-ubuntu18.04 as base
+LABEL maintainer="Sheng Gui <sheng.gui@intel.com>"
+
+WORKDIR /root
+RUN rm -rf /root/demos && \
+    git clone https://github.com/occlum/occlum.git && \
+    cp -r occlum/demos /root/demos && \
+    rm -rf /root/occlum
+
+WORKDIR /root/demos/openvino
+RUN bash -x install_cmake.sh && \
+    bash -x download_and_build_openvino_2021.sh && \
+    bash -x download_openvino_model.sh
+
+WORKDIR /root


### PR DESCRIPTION
add support for OpenVINO 2021.3
    1. Replace the original TBB with OneTBB v2020.3
    2. Replace the 2019_R3 with DLDT 2021.3
    3. Add some dependent lib to the occlum image
    4. Update some of the parameters in occlum.json

add OpenVINO2021 test workflow