### PR TITLE
Remove the cpu online file for glibc

### DIFF
--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -326,7 +326,7 @@ jobs:
       run: echo "OCCLUM_VERSION=$(grep "Version =" src/pal/include/occlum_version.h |  awk '{print $4}')" >> $GITHUB_ENV
 
     - name: Create container
-      run: docker run -itd --name=pytorch_test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
+      run: docker run -itd --cpuset-cpus="0" --name=pytorch_test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
 
     - name: Build dependencies
       run: docker exec pytorch_test bash -c "cd /root/occlum; make submodule"
@@ -435,7 +435,7 @@ jobs:
       run: echo "OCCLUM_VERSION=$(grep "Version =" src/pal/include/occlum_version.h |  awk '{print $4}')" >> $GITHUB_ENV
 
     - name: Create container
-      run: docker run -itd --name=python_glibc_support_test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
+      run: docker run -itd --cpuset-cpus="0" --name=python_glibc_support_test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-ubuntu18.04
 
     - name: Build dependencies
       run: docker exec python_glibc_support_test bash -c "cd /root/occlum; make submodule"

--- a/tools/occlum
+++ b/tools/occlum
@@ -166,10 +166,8 @@ cmd_init() {
     mkdir -p image/etc
     local occlum_glibc_lib=/opt/occlum/glibc/lib
     local occlum_glibc_etc=/opt/occlum/glibc/etc
-    local cpu_lib=/sys/devices/system/cpu
     if [ -d "$occlum_glibc_lib" ]; then
         mkdir -p "image/$occlum_glibc_lib"
-        mkdir -p "image/$cpu_lib"
         mkdir -p "image/$occlum_glibc_etc"
     fi
     # add default /etc/hosts
@@ -207,8 +205,6 @@ cmd_init() {
         fi
         cp -t "image/$occlum_glibc_etc" \
             /etc/localtime
-        cp -t "image/$cpu_lib" \
-            "$cpu_lib/online"
     fi
 
     mkdir -p initfs


### PR DESCRIPTION
Checkout here for the implementation of `__get_nprocs `,
https://github.com/bminor/glibc/blob/glibc-2.27/sysdeps/unix/sysv/linux/getsysstats.c#L214

Since `/proc/cpuinfo` is supported in Occlum, we can remove the online file from the image.