### PR TITLE
Use aliyunlinux2 as default image for aliyunlinux

### DIFF
--- a/.github/workflows/build_and_push_aliyunlinux_image.yml
+++ b/.github/workflows/build_and_push_aliyunlinux_image.yml
@@ -51,7 +51,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./tools/docker/Dockerfile.aliyunlinux3
+        file: ./tools/docker/Dockerfile.aliyunlinux2
         platforms: linux/amd64
         build-args: OCCLUM_BRANCH=${{ env.OCCLUM_BRANCH }}
         push: true


### PR DESCRIPTION
There is some known issue for aliyunlinux3 base image. So change default image back to aliyunlinux2.