### PR TITLE
Fix the return value of sched_getaffinity.

### DIFF
--- a/src/libos/src/sched/cpu_set.rs
+++ b/src/libos/src/sched/cpu_set.rs
@@ -20,8 +20,10 @@ pub struct CpuSet {
 
 impl CpuSet {
     /// Returns the length of a CPU set in bytes.
+    ///
+    /// The length must be an integer multiple of sizeof(long) in Linux.
     pub fn len() -> usize {
-        align_up(Self::ncores(), 8) / 8
+        align_up(align_up(Self::ncores(), 8) / 8, 8)
     }
 
     /// Returns the number CPU of cores in a CPU set.

--- a/src/libos/src/sched/syscalls.rs
+++ b/src/libos/src/sched/syscalls.rs
@@ -14,11 +14,6 @@ pub fn do_sched_getaffinity(pid: pid_t, buf_size: size_t, buf_ptr: *mut u8) -> R
             return_errno!(EINVAL, "buf size is not big enough");
         }
 
-        // Linux stores the cpumask in an array of "unsigned long" so the buffer needs to be
-        // multiple of unsigned long. However, Occlum doesn't have this restriction.
-        if (buf_size & (std::mem::size_of::<u64>() - 1) != 0) {
-            warn!("cpuset buf size is not a multiple of unsigned long");
-        }
         CpuSet::len()
     };
     let mut buf_slice = {


### PR DESCRIPTION
The return value of the raw sched_getaffinity syscall must be an integer multiple of sizeof(long) in Linux.

Linux code: 
```
unsigned int retlen = min(len, cpumask_size());

static inline unsigned int cpumask_size(void)
{
	return BITS_TO_LONGS(nr_cpumask_bits) * sizeof(long);
}
```