### PR TITLE
Fix some process VM error when enabling GCC 10

### DIFF
--- a/src/libos/src/vm/process_vm.rs
+++ b/src/libos/src/vm/process_vm.rs
@@ -101,7 +101,7 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
         let process_layout = elf_layouts.iter().chain(other_layouts.iter()).fold(
             VMLayout::new_empty(),
             |mut process_layout, sub_layout| {
-                process_layout.extend(&sub_layout);
+                process_layout.add(&sub_layout);
                 process_layout
             },
         );

--- a/src/libos/src/vm/process_vm.rs
+++ b/src/libos/src/vm/process_vm.rs
@@ -248,7 +248,8 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
                 );
 
                 // Set the remaining part to zero based on alignment
-                empty_end_offset = align_up(mem_start_offset + file_size, alignment);
+                debug_assert!(file_size <= mem_size);
+                empty_end_offset = align_up(mem_start_offset + mem_size, alignment);
                 for b in &mut elf_proc_buf[mem_start_offset + file_size..empty_end_offset] {
                     *b = 0;
                 }

--- a/src/libos/src/vm/process_vm.rs
+++ b/src/libos/src/vm/process_vm.rs
@@ -108,11 +108,7 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
 
         // Now that we end up with the memory layout required by the process,
         // let's allocate the memory for the process
-        let process_range = {
-            // TODO: ensure alignment through USER_SPACE_VM_MANAGER, not by
-            // preserving extra space for alignment
-            USER_SPACE_VM_MANAGER.alloc(process_layout.align() + process_layout.size())?
-        };
+        let process_range = { USER_SPACE_VM_MANAGER.alloc(process_layout)? };
         let process_base = process_range.range().start();
         // Use the vm_manager to manage the whole process VM (including mmap region)
         let mut vm_manager = VMManager::from(process_base, process_range.range().size())?;

--- a/src/libos/src/vm/user_space_vm.rs
+++ b/src/libos/src/vm/user_space_vm.rs
@@ -16,7 +16,8 @@ impl UserSpaceVMManager {
         }
     }
 
-    pub fn alloc(&self, size: usize) -> Result<UserSpaceVMRange> {
+    pub fn alloc(&self, vm_layout: VMLayout) -> Result<UserSpaceVMRange> {
+        let size = align_up(vm_layout.size(), vm_layout.align());
         let vm_range = unsafe {
             let ptr = sgx_alloc_rsrv_mem(size);
             let perm = MemPerm::READ | MemPerm::WRITE;

--- a/src/libos/src/vm/vm_layout.rs
+++ b/src/libos/src/vm/vm_layout.rs
@@ -21,13 +21,28 @@ impl VMLayout {
         }
     }
 
-    pub fn extend(&mut self, more_space: &VMLayout) -> &mut Self {
+    // This is used to add "more_space" to VM layout
+    pub fn add(&mut self, more_space: &VMLayout) -> &mut Self {
         if more_space.size == 0 {
             return self;
         }
 
         self.size = align_up(self.size, more_space.align) + more_space.size;
         self.align = max(self.align, more_space.align);
+        self
+    }
+
+    // This is used to get the bigger and aligned VM layout
+    pub fn extend(&mut self, new_space: &VMLayout) -> &mut Self {
+        if new_space.size == 0 {
+            return self;
+        }
+
+        self.align = max(self.align, new_space.align);
+        self.size = {
+            let size = max(self.size, new_space.size);
+            align_up(size, self.align)
+        };
         self
     }
 


### PR DESCRIPTION
(1) Fix uninitialized elf memory for loadable segment

(2) Fix an error when calculating elf memory usage
VMLayout was mistakenly used to calculate the memory usage. This
commit is to fix this and separate VMLayout "add" and "extend"
methods.

(3) Don't allocate extra memory if already aligned
