### PR TITLE
Re-enable aliyunlinux 3 image as default aliyunlinux image

### DIFF
--- a/.github/workflows/build_and_push_aliyunlinux_image.yml
+++ b/.github/workflows/build_and_push_aliyunlinux_image.yml
@@ -51,11 +51,11 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./tools/docker/Dockerfile.aliyunlinux2
+        file: ./tools/docker/Dockerfile.aliyunlinux3
         platforms: linux/amd64
         build-args: OCCLUM_BRANCH=${{ env.OCCLUM_BRANCH }}
         push: true
-        tags: occlum/occlum:${{ env.RELEASE_VERSION }}-aliyunlinux
+        tags: occlum/occlum:${{ env.RELEASE_VERSION }}-aliyunlinux3
 
 
   Make_test_on_aliyunlinux:
@@ -72,7 +72,7 @@ jobs:
       run: echo "OCCLUM_VERSION=$(grep 'Version =' src/pal/include/occlum_version.h | awk '{print $4}')" >> $GITHUB_ENV;
 
     - name: Create container with Aliyun Linux image
-      run: docker run -itd --name=alinux-test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-aliyunlinux
+      run: docker run -itd --name=alinux-test -v $GITHUB_WORKSPACE:/root/occlum occlum/occlum:${{ env.OCCLUM_VERSION }}-aliyunlinux3
 
     - name: Build dependencies
       run:  docker exec alinux-test bash -c "cd /root/occlum; make submodule"

--- a/tools/docker/Dockerfile.aliyunlinux3
+++ b/tools/docker/Dockerfile.aliyunlinux3
@@ -3,7 +3,7 @@ FROM alpine:3.11 AS alpine
 RUN apk update && \
     apk --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
-FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3
+FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3:3.210714.1
 
 LABEL maintainer="Chunyang Hui <sanqian.hcy@antgroup.com>"
 
@@ -12,8 +12,6 @@ LABEL maintainer="Chunyang Hui <sanqian.hcy@antgroup.com>"
 SHELL ["/bin/bash", "-c"]
 
 RUN yum install -y --nogpgcheck \
-        alinux-release-experimentals && \
-        yum install -y --nogpgcheck \
         astyle \
         autoconf \
         automake \
@@ -45,7 +43,7 @@ RUN yum install -y --nogpgcheck \
         libxml2-devel \
         libtool \
         pkgconfig \
-        python \
+        python2 \
         kmod \
         make \
         mod_ssl \
@@ -167,7 +165,6 @@ ENV LD_LIBRARY_PATH="/opt/intel/sgxpsw/aesm:/usr/lib64/:/usr/local/lib:/opt/inte
 # Install the latest version of Occlum
 WORKDIR /root/occlum
 RUN rm -rf occlum && \
-    source scl_source enable devtoolset-8 && \
     git clone -b $OCCLUM_BRANCH https://github.com/occlum/occlum && \
     cd occlum && \
     source /opt/intel/sgxsdk/environment && \

--- a/tools/docker/build_image.sh
+++ b/tools/docker/build_image.sh
@@ -21,6 +21,7 @@ USAGE:
     The name of the OS distribution that the Docker image is based on. Currently, <OS_NAME> must be one of the following values:
         ubuntu18.04         Use Ubuntu 18.04 as the base image
         centos8.2           Use CentOS 8.2 as the base image
+        aliyunlinux3        Use AliyunLinux 3 as the base image
 
 The resulting Docker image will have "occlum/occlum:<OCCLUM_LABEL>-<OS_NAME>" as its label.
 EOF
@@ -43,7 +44,7 @@ function check_item_in_list() {
     [[ $list =~ (^|[[:space:]])$item($|[[:space:]]) ]]
 }
 
-check_item_in_list "$os_name" "ubuntu18.04 centos8.2" || report_error
+check_item_in_list "$os_name" "ubuntu18.04 centos8.2 aliyunlinux3" || report_error
 
 cd "$script_dir/.."
 docker build -f "$script_dir/Dockerfile.$os_name" -t "occlum/occlum:$occlum_label-$os_name" --build-arg OCCLUM_BRANCH=$occlum_branch .


### PR DESCRIPTION
After fixing some process VM errors for GCC 10, alinux3 can work now.

I have tested with my own repo. Please check out here:https://github.com/jessehui/occlum/actions/runs/1054798983

Please merge #548 first. Then I will do a rebase.