### PR TITLE
Fix the wrong value returned from getcwd

### DIFF
--- a/src/libos/src/fs/syscalls.rs
+++ b/src/libos/src/fs/syscalls.rs
@@ -369,14 +369,15 @@ pub fn do_getcwd(buf_ptr: *mut u8, size: usize) -> Result<isize> {
     };
 
     let cwd = fs_ops::do_getcwd()?;
-
     if cwd.len() + 1 > buf.len() {
         return_errno!(ERANGE, "buf is not long enough");
     }
     buf[..cwd.len()].copy_from_slice(cwd.as_bytes());
-    buf[cwd.len()] = 0;
+    buf[cwd.len()] = b'\0';
 
-    Ok(buf.len() as isize)
+    // The user-level library returns the pointer of buffer, the kernel just returns
+    // the length of the buffer filled (which includes the ending '\0' character).
+    Ok((cwd.len() + 1) as isize)
 }
 
 pub fn do_rename(oldpath: *const i8, newpath: *const i8) -> Result<isize> {

--- a/test/mkdir/main.c
+++ b/test/mkdir/main.c
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <errno.h>
 #include <fcntl.h>
 #include "test_fs.h"
@@ -115,6 +116,15 @@ static int __test_chdir(const char *dir_path) {
     }
     if (strcmp(buf, dir_path)) {
         THROW_ERROR("the cwd is incorrect after chdir");
+    }
+
+    // Check getcwd via explicit syscall
+    int ret = syscall(__NR_getcwd, buf, sizeof(buf));
+    if (ret < 0) {
+        THROW_ERROR("failed to call via explicit syscall");
+    }
+    if (ret != strlen(dir_path) + 1) {
+        THROW_ERROR("failed to check the return value from kernel");
     }
     return 0;
 }


### PR DESCRIPTION
`getcwd` should return the length of buffer filled