### PR TITLE
Add similation and debug mode occlum package check and support

### DIFF
--- a/.github/workflows/rune_test.yml
+++ b/.github/workflows/rune_test.yml
@@ -67,7 +67,7 @@ jobs:
       run: docker exec $rune_test bash -c "occlum-gcc -o hello_world hello_world.c;
         occlum new occlum_instance && cd occlum_instance;
         cp ../hello_world image/bin/ && occlum build;
-        occlum package occlum_instance.tar.gz;
+        occlum package --debug occlum_instance.tar.gz;
         docker build . -t occlum-app -f /root/Dockerfile-occlum"
 
     - name: Run Occlum image

--- a/demos/deployment/Dockerfile_template.centos8.2
+++ b/demos/deployment/Dockerfile_template.centos8.2
@@ -25,8 +25,10 @@ ENV PATH="/opt/occlum/build/bin:/usr/local/occlum/bin:$PATH"
 
 
 # packager stage:
-# Users can build their own applications and put to occlum instance. And then use "occlum package"
-# to get a minimum subset of files to run in deployment environment.
+# Users can build their own applications and put to occlum instance.
+# And then use "occlum package" to get a minimum subset of files to run in deployment environment.
+# In this demo, the occlum instance is built in debug mode.
+# So "--debug" flag is required for the "occlum package".
 FROM base as packager
 RUN yum install -y fuse-libs libtool make gdb git && \
     cd /root && \
@@ -41,7 +43,7 @@ RUN yum install -y fuse-libs libtool make gdb git && \
     cd /root/demos/hello_c && \
     make && cp hello_world /root/occlum-instance/image/bin && \
     cd /root/occlum-instance && occlum build && \
-    occlum package
+    occlum package --debug
 
 
 # deployer stage:

--- a/demos/deployment/Dockerfile_template.ubuntu18.04
+++ b/demos/deployment/Dockerfile_template.ubuntu18.04
@@ -18,8 +18,10 @@ ENV PATH="/opt/occlum/build/bin:/usr/local/occlum/bin:$PATH"
 
 
 # packager stage:
-# Users can build their own applications and put to occlum instance. And then use "occlum package"
-# to get a minimum subset of files to run in deployment environment.
+# Users can build their own applications and put to occlum instance.
+# And then use "occlum package" to get a minimum subset of files to run in deployment environment.
+# In this demo, the occlum instance is built in debug mode.
+# So "--debug" flag is required for the "occlum package".
 FROM base as packager
 WORKDIR /root
 RUN apt-get update && \
@@ -35,7 +37,7 @@ RUN apt-get update && \
     cd /root/demos/hello_c && \
     make && cp hello_world /root/occlum-instance/image/bin && \
     cd /root/occlum-instance && occlum build && \
-    occlum package
+    occlum package --debug
 
 
 # deployer stage:

--- a/tools/occlum
+++ b/tools/occlum
@@ -69,6 +69,8 @@ Usage:
         All runtime dependencies required by the Occlum instance---except Intel SGX driver,
         enable_rdfsbase kernel module, and Intel SGX PSW---are included in the package.
         If package_name is not specified, the directory name of Occlum instance will be used.
+        In default only HW release mode package is supported. Debug or simulation mode package
+        could be supported by adding "--debug" flag.
 
     occlum gdb <program_name> <program_args>
         Debug the program running inside an SGX enclave with GDB.
@@ -390,37 +392,55 @@ cmd_stop() {
 cmd_package() {
     check_has_built
 
-    SGX_MODE=$(cat $instance_dir/.sgx_mode)
-    if [[ -n $SGX_MODE && "$SGX_MODE" != "HW" ]]; then
-        echo '"occlum package" command should only be used for an Occlum instance of SGX hardware mode, not the simulation mode.'
-        echo 'Please run "occlum build --sgx-mode HW" and then use "occlum package"'
+    debug="false"
+    instance_base_name=$(basename $instance_dir)
+    package_name="$instance_base_name.tar.gz"
+    while [ -n "$1" ]; do
+        case "$1" in
+        --debug)  debug="true" ; shift ;;
+        *) package_name=$1 ; shift ;;
+        esac
+    done
+
+    if [[ "$package_name" != *.tar.gz ]]; then
+        package_name="$package_name.tar.gz"
+    fi
+
+    if [[ "`get_enclave_debuggable_flag`" == "true" && "$debug" != "true" ]]; then
+        echo 'Warning: current Occlum instance is configured as "debuggable".'
+        echo '(If it is not expected, you can modify the Occlum.json "metadata" - "debuggable" field to "false" and build again. And then use "occlum package")'
+        echo 'Or, use "occlum package --debug" to support debug mode package'
         exit 1
     fi
 
-    instance_base_name=$(basename $instance_dir)
-    if [[ -z "$@" ]]; then
-        package_name="$instance_base_name.tar.gz"
-    else
-        if [[ "$@" == *.tar.gz ]];then
-            package_name="$@"
-        else
-            package_name="$@.tar.gz"
-        fi
+    SGX_MODE=$(cat $instance_dir/.sgx_mode)
+    if [[ -n $SGX_MODE && "$SGX_MODE" != "HW" && "$debug" != "true" ]]; then
+        echo '"occlum package" command should only be used for an Occlum instance of SGX hardware mode, not the simulation mode.'
+        echo 'Please run "occlum build --sgx-mode HW" and then use "occlum package"'
+        echo 'Or, use "occlum package --debug" to support similation mode package'
+        exit 1
     fi
 
     rm -f $package_name
 
-    cd .. && tar -cvzf $instance_dir/$package_name $instance_base_name/Occlum.json $instance_base_name/build/bin \
-        $instance_base_name/build/lib/libocclum-libos.signed.so $instance_base_name/build/lib/libocclum-pal.so* \
-        $instance_base_name/build/mount $instance_base_name/build/Occlum.json.protected \
-        $instance_base_name/build/initfs $instance_base_name/build/.Occlum_sys.json.protected \
-        $instance_base_name/initfs $instance_base_name/run \
-        $instance_base_name/.__occlum_status $instance_base_name/.sgx_mode
-
-    if [ "`get_enclave_debuggable_flag`" == "true" ]; then
-        echo 'Warning: current Occlum instance is configured as "debuggable".'
-        echo '(If it is not expected, you can modify the Occlum.json "metadata" - "debuggable" field to "false" and build again. And then use "occlum package")'
+    pkg_files="\
+    $instance_base_name/Occlum.json \
+    $instance_base_name/build/bin \
+    $instance_base_name/build/lib/libocclum-libos.signed.so \
+    $instance_base_name/build/lib/libocclum-pal.so* \
+    $instance_base_name/build/mount $instance_base_name/build/Occlum.json.protected \
+    $instance_base_name/build/initfs $instance_base_name/build/.Occlum_sys.json.protected \
+    $instance_base_name/initfs $instance_base_name/run \
+    $instance_base_name/.__occlum_status $instance_base_name/.sgx_mode \
+    "
+    if [[ "$debug" == "true" && "$SGX_MODE" != "HW" ]]; then
+        sim_files="\
+        $instance_base_name/build/lib/libocclum-libos_sim.so* \
+        $instance_base_name/build/lib/libocclum-pal_sim.so* \
+        "
     fi
+
+    cd .. && tar -cvzf $instance_dir/$package_name $pkg_files $sim_files
 
     echo "The package $package_name is generated successfully"
 }


### PR DESCRIPTION
Signed-off-by: Zheng, Qi <huaiqing.zq@antgroup.com>

In default only HW mode package is supported. 
But in some cases, such as debug purpose or on no HW SGX env, simulation mode package may be required as well.
Adding a "--debug" flag in "occlum package" to support simulation mode occlum image package.