### PR TITLE
Fix Cluster Serving demo classpath

### DIFF
--- a/demos/cluster_serving/environment.sh
+++ b/demos/cluster_serving/environment.sh
@@ -4,9 +4,9 @@
 export CORE_NUM=`nproc`
 export REDIS_VERSION=6.0.6
 export REDIS_HOME=redis-${REDIS_VERSION}
-export FLINK_VERSION=1.10.1
+export FLINK_VERSION=1.11.3
 export FLINK_HOME=flink-${FLINK_VERSION}
 export ANALYTICS_ZOO_VERSION=0.10.0
 export BIGDL_VERSION=0.12.2
 export SPARK_VERSION=2.4.3
-
+export no_proxy=127.0.0.1

--- a/demos/cluster_serving/install-dependencies.sh
+++ b/demos/cluster_serving/install-dependencies.sh
@@ -26,5 +26,3 @@ mkdir resnet50 && \
 cd resnet50 && \
 wget -c "https://sourceforge.net/projects/analytics-zoo/files/analytics-zoo-models/openvino/2018_R5/resnet_v1_50.bin/download" -O resnet_v1_50.bin && \
 wget -c "https://sourceforge.net/projects/analytics-zoo/files/analytics-zoo-models/openvino/2018_R5/resnet_v1_50.xml/download" -O resnet_v1_50.xml
-
-

--- a/demos/cluster_serving/start-flink-jobmanager.sh
+++ b/demos/cluster_serving/start-flink-jobmanager.sh
@@ -11,6 +11,9 @@ flink_version=$FLINK_VERSION
 
 echo "### Launching Flink Jobmanager ###"
 
+jars=(${flink_home}/lib/*.jar)
+jars_cp=$( IFS=$':'; echo "${jars[*]}" )
+
 java \
     -Xms5g \
     -Xmx10g \
@@ -21,7 +24,7 @@ java \
     -Dlog.file=${flink_home}/log/flink-sgx-standalonesession-1-sgx-ICX-LCC.log \
     -Dlog4j.configuration=file:${flink_home}/conf/log4j.properties \
     -Dlogback.configurationFile=file:${flink_home}/conf/logback.xml \
-    -classpath ${flink_home}/lib/flink-table_2.11-${flink_version}.jar:${flink_home}/lib/flink-table-blink_2.11-${flink_version}.jar:${flink_home}/lib/log4j-1.2.17.jar:${flink_home}/lib/slf4j-log4j12-1.7.15.jar:${flink_home}/lib/flink-dist_2.11-${flink_version}.jar::: org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint \
+    -classpath ${jars_cp} org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint \
     --configDir ${flink_home}/conf \
     -D rest.bind-address=${job_manager_host} \
     -D rest.bind-port=${job_manager_rest_port} \

--- a/demos/cluster_serving/start-flink-taskmanager.sh
+++ b/demos/cluster_serving/start-flink-taskmanager.sh
@@ -43,7 +43,7 @@ run_taskmanager() {
     -Dlog.file=$log \
     -Dlog4j.configuration=file:/opt/conf/log4j.properties \
     -Dlogback.configurationFile=file:/opt/conf/logback.xml \
-    -classpath /bin/lib/flink-table-blink_2.11-1.10.1.jar:/bin/lib/flink-table_2.11-1.10.1.jar:/bin/lib/log4j-1.2.17.jar:/bin/lib/slf4j-log4j12-1.7.15.jar:/bin/lib/flink-dist_2.11-1.10.1.jar org.apache.flink.runtime.taskexecutor.TaskManagerRunner \
+    -classpath /bin/lib/* org.apache.flink.runtime.taskexecutor.TaskManagerRunner \
     -Dorg.apache.flink.shaded.netty4.io.netty.tryReflectionSetAccessible=true \
     -Dorg.apache.flink.shaded.netty4.io.netty.eventLoopThreads=${core_num} \
     -Dcom.intel.analytics.zoo.shaded.io.netty.tryReflectionSetAccessible=true \

--- a/demos/cluster_serving/start-redis.sh
+++ b/demos/cluster_serving/start-redis.sh
@@ -5,4 +5,4 @@ echo "### Launching Redis ###"
 REDIS_PORT=6379
 
 $REDIS_HOME/src/redis-server --port $REDIS_PORT \
-    --protected-mode no --maxmemory 10g | tee ./redis-sgx.log
+    --protected-mode no --maxmemory 6g | tee ./redis-sgx.log


### PR DESCRIPTION
* Change hard code classpath into path/*, such that changing Flink version will not break this demo.
* Reduce redis memory
* Change Flink version to 1.11.3
* Add no_proxy to avoid network problem in proxy