### PR TITLE
SGX_SDK environment should not be changed if it is already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ install: minimal_sgx_libs
 
 	@echo "Installation is done."
 
-SGX_SDK=/opt/intel/sgxsdk
+SGX_SDK ?= /opt/intel/sgxsdk
 # Install minimum sgx-sdk set to support Occlum cmd execution in non-customized sgx-sdk environment
 minimal_sgx_libs: $(SGX_SDK)/lib64/libsgx_uae_service_sim.so $(SGX_SDK)/lib64/libsgx_quote_ex_sim.so
 	@echo "Install needed sgx-sdk tools ..."


### PR DESCRIPTION
If I add SGX_SDK environment to /etc/profile or other environment path then SGX_SDK should not be changed.Maybe the directory which I want to install is not '/opt/intel/'