### PR TITLE
Add updated RATS TLS demo

### DIFF
--- a/demos/rats-tls/0001-Consider-SGX_QL_QV_RESULT_OUT_OF_DATE-as-success.patch
+++ b/demos/rats-tls/0001-Consider-SGX_QL_QV_RESULT_OUT_OF_DATE-as-success.patch
@@ -1,0 +1,30 @@
+From b6d9a22fdac5c35565960d046f1985df0049cbe2 Mon Sep 17 00:00:00 2001
+From: "Zheng, Qi" <huaiqing.zq@antgroup.com>
+Date: Wed, 8 Sep 2021 14:52:36 +0800
+Subject: [PATCH] Consider SGX_QL_QV_RESULT_OUT_OF_DATE as success
+
+Signed-off-by: Zheng, Qi <huaiqing.zq@antgroup.com>
+---
+ rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c b/rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c
+index ba744762..29d84910 100644
+--- a/rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c
++++ b/rats-tls/src/verifiers/sgx-ecdsa/verify_evidence.c
+@@ -181,11 +181,11 @@ enclave_verifier_err_t sgx_ecdsa_verify_evidence(enclave_verifier_ctx_t *ctx,
+ 	/* Check verification result */
+ 	switch (quote_verification_result) {
+ 	case SGX_QL_QV_RESULT_OK:
++	case SGX_QL_QV_RESULT_OUT_OF_DATE:
+ 		RTLS_INFO("verification completed successfully.\n");
+ 		err = ENCLAVE_VERIFIER_ERR_NONE;
+ 		break;
+ 	case SGX_QL_QV_RESULT_CONFIG_NEEDED:
+-	case SGX_QL_QV_RESULT_OUT_OF_DATE:
+ 	case SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED:
+ 	case SGX_QL_QV_RESULT_SW_HARDENING_NEEDED:
+ 	case SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED:
+-- 
+2.25.1
+

--- a/demos/rats-tls/README.md
+++ b/demos/rats-tls/README.md
@@ -1,0 +1,41 @@
+# Demo of RATS TLS server/client running in Occlum
+
+This project demonstrates how to run RATS TLS server/client in Occlum [`RATS TLS`](https://github.com/alibaba/inclavare-containers/tree/master/rats-tls).
+
+## Prerequisites
+
+First make sure the DCAP demo is working fine on your platform, either host or container ENV.
+Details could be refer to [`DCAP demo`](../remote_attestation/dcap/).
+
+As the DCAP version on Occlum may not be the latest one, could be inconsistent with the DCAP version in PCCS server.
+Thus the quote verify may return `SGX_QL_QV_RESULT_OUT_OF_DATE` which means unsuccess.
+
+In this demo, one [`workaround patch`](./0001-Consider-SGX_QL_QV_RESULT_OUT_OF_DATE-as-success.patch) is applied when building the RATS TLS to avoid above failure.
+
+## Steps
+
+Step 1: Download and build RATS TLS.
+```shell
+./download_and_build_rats_tls.sh
+```
+When completed, the resulting samples are installed in `/usr/share/rats-tls/samples`.
+The libraries are installed in `/usr/local/lib/rats-tls`.
+
+Step 2: Build and run RATS TLS server in Occlum on background.
+```shell
+./occlum_build_and_run_rats_tls_server.sh
+```
+
+Step 3: Then build and run RATS TLS client in Occlum.
+```shell
+./occlum_build_and_run_rats_tls_client.sh
+```
+
+If success, the server SGX `mrsigner` and `mrenclave` will be printed out.
+```shell
+...
+[INFO] Server's SGX identity:
+[INFO]   . MRENCLAVE = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+[INFO]   . MRSIGNER  = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+...
+```

--- a/demos/rats-tls/download_build_rats_tls.sh
+++ b/demos/rats-tls/download_build_rats_tls.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+branch=master
+
+rm -rf inclavare-containers
+git clone -b $branch https://github.com/alibaba/inclavare-containers
+
+cd inclavare-containers && git apply ../0001-Consider-SGX_QL_QV_RESULT_OUT_OF_DATE-as-success.patch
+cd rats-tls
+cmake -DRATS_TLS_BUILD_MODE="occlum" -DBUILD_SAMPLES=on -H. -Bbuild
+make -C build install

--- a/demos/rats-tls/occlum_build_and_run_rats_tls_client.sh
+++ b/demos/rats-tls/occlum_build_and_run_rats_tls_client.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+install_sample_dir=/usr/share/rats-tls/samples
+install_lib_dir=/usr/local/lib/rats-tls
+
+rm -rf occlum_client
+occlum new occlum_client
+cd occlum_client
+
+# Copy libs/files to prepare occlum image
+cp ${install_sample_dir}/rats-tls-client image/bin
+cp /lib/x86_64-linux-gnu/libdl.so.2 image/opt/occlum/glibc/lib
+cp /usr/lib/x86_64-linux-gnu/libssl.so.1.1 image/opt/occlum/glibc/lib
+cp /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 image/opt/occlum/glibc/lib
+mkdir -p image/usr/local/lib
+cp -rf ${install_lib_dir} image/usr/local/lib/
+
+occlum build
+occlum run /bin/rats-tls-client -m

--- a/demos/rats-tls/occlum_build_and_run_rats_tls_server.sh
+++ b/demos/rats-tls/occlum_build_and_run_rats_tls_server.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+install_sample_dir=/usr/share/rats-tls/samples
+install_lib_dir=/usr/local/lib/rats-tls
+
+rm -rf occlum_server
+occlum new occlum_server
+cd occlum_server
+
+# Copy libs/files to prepare occlum image
+cp ${install_sample_dir}/rats-tls-server image/bin
+cp /lib/x86_64-linux-gnu/libdl.so.2 image/opt/occlum/glibc/lib
+cp /usr/lib/x86_64-linux-gnu/libssl.so.1.1 image/opt/occlum/glibc/lib
+cp /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 image/opt/occlum/glibc/lib
+mkdir -p image/usr/local/lib
+cp -rf ${install_lib_dir} image/usr/local/lib/
+
+occlum build
+
+echo "Run the rats-tls server on background ..."
+occlum run /bin/rats-tls-server -m &


### PR DESCRIPTION
Signed-off-by: Zheng, Qi <huaiqing.zq@antgroup.com>

RATS TLS is an evolved version from Enclave TLS.
Once RATS TLS is stable, the enclave TLS will be abandoned.
Adding the RATS TLS demo to prepare for the change.