### PR TITLE
Fix the return error code of file operations

### DIFF
--- a/src/libos/src/fs/inode_file.rs
+++ b/src/libos/src/fs/inode_file.rs
@@ -14,7 +14,7 @@ pub struct INodeFile {
 impl File for INodeFile {
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         if !self.access_mode.readable() {
-            return_errno!(EACCES, "File not readable");
+            return_errno!(EBADF, "File not readable");
         }
         let mut offset = self.offset.lock().unwrap();
         let len = self.inode.read_at(*offset, buf).map_err(|e| errno!(e))?;
@@ -24,7 +24,7 @@ impl File for INodeFile {
 
     fn write(&self, buf: &[u8]) -> Result<usize> {
         if !self.access_mode.writable() {
-            return_errno!(EACCES, "File not writable");
+            return_errno!(EBADF, "File not writable");
         }
         let mut offset = self.offset.lock().unwrap();
         if self.status_flags.read().unwrap().always_append() {
@@ -38,7 +38,7 @@ impl File for INodeFile {
 
     fn read_at(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
         if !self.access_mode.readable() {
-            return_errno!(EACCES, "File not readable");
+            return_errno!(EBADF, "File not readable");
         }
         let len = self.inode.read_at(offset, buf)?;
         Ok(len)
@@ -46,7 +46,7 @@ impl File for INodeFile {
 
     fn write_at(&self, offset: usize, buf: &[u8]) -> Result<usize> {
         if !self.access_mode.writable() {
-            return_errno!(EACCES, "File not writable");
+            return_errno!(EBADF, "File not writable");
         }
         let len = self.inode.write_at(offset, buf)?;
         Ok(len)
@@ -54,7 +54,7 @@ impl File for INodeFile {
 
     fn readv(&self, bufs: &mut [&mut [u8]]) -> Result<usize> {
         if !self.access_mode.readable() {
-            return_errno!(EACCES, "File not readable");
+            return_errno!(EBADF, "File not readable");
         }
         let mut offset = self.offset.lock().unwrap();
         let mut total_len = 0;
@@ -73,7 +73,7 @@ impl File for INodeFile {
 
     fn writev(&self, bufs: &[&[u8]]) -> Result<usize> {
         if !self.access_mode.writable() {
-            return_errno!(EACCES, "File not writable");
+            return_errno!(EBADF, "File not writable");
         }
         let mut offset = self.offset.lock().unwrap();
         if self.status_flags.read().unwrap().always_append() {
@@ -138,7 +138,7 @@ impl File for INodeFile {
 
     fn set_len(&self, len: u64) -> Result<()> {
         if !self.access_mode.writable() {
-            return_errno!(EACCES, "File not writable. Can't set len.");
+            return_errno!(EBADF, "File not writable. Can't set len.");
         }
         self.inode.resize(len as usize)?;
         Ok(())
@@ -156,7 +156,7 @@ impl File for INodeFile {
 
     fn iterate_entries(&self, writer: &mut dyn DirentWriter) -> Result<usize> {
         if !self.access_mode.readable() {
-            return_errno!(EACCES, "File not readable. Can't read entry.");
+            return_errno!(EBADF, "File not readable. Can't read entry.");
         }
         let mut offset = self.offset.lock().unwrap();
         let mut dir_ctx = DirentWriterContext::new(*offset, writer);


### PR DESCRIPTION
According to https://man7.org/linux/man-pages/man2/write.2.html and https://man7.org/linux/man-pages/man2/read.2.html, If the file is not opened for writing or reading, should return EBADF.