### PR TITLE
Fix missing nss_files in tensorflow demo

### DIFF
--- a/demos/tensorflow/tensorflow_serving/tensorflow_serving.yaml
+++ b/demos/tensorflow/tensorflow_serving/tensorflow_serving.yaml
@@ -18,3 +18,10 @@ targets:
     copy: 
       - files:
         - ../hosts
+  # copy nss files
+  target: /opt/occlum/glibc/lib
+    copy: 
+      - from: /opt/occlum/glibc/lib
+        files: 
+          - libnss_files.so.2
+          - libnss_compat.so.2


### PR DESCRIPTION
libnss files seem not to be copied automatically