### PR TITLE
Fix the C++ Link issue and Add the static lib

### DIFF
--- a/demos/remote_attestation/dcap/c_app/dcap_quote.h
+++ b/demos/remote_attestation/dcap/c_app/dcap_quote.h
@@ -10,15 +10,15 @@
 #include "sgx_pce.h"
 #include "sgx_error.h"
 
-void *dcap_quote_open(void);
+extern "C" void *dcap_quote_open(void);
 
-uint32_t dcap_get_quote_size(void *handle);
+extern "C" uint32_t dcap_get_quote_size(void *handle);
 
-int32_t dcap_generate_quote(void *handle, uint8_t *quote_buf, const sgx_report_data_t *report_data);
+extern "C" int32_t dcap_generate_quote(void *handle, uint8_t *quote_buf, const sgx_report_data_t *report_data);
 
-uint32_t dcap_get_supplemental_data_size(void *handle);
+extern "C" uint32_t dcap_get_supplemental_data_size(void *handle);
 
-int32_t dcap_verify_quote(void *handle,
+extern "C" int32_t dcap_verify_quote(void *handle,
                           const uint8_t *quote_buf,
                           uint32_t quote_size,
                           uint32_t *collateral_expiration_status,
@@ -27,4 +27,4 @@ int32_t dcap_verify_quote(void *handle,
                           uint8_t *supplemental_data);
 
 
-void dcap_quote_close(void *handle);
+extern "C" void dcap_quote_close(void *handle);

--- a/demos/remote_attestation/dcap/dcap_lib/Cargo.toml
+++ b/demos/remote_attestation/dcap/dcap_lib/Cargo.toml
@@ -11,4 +11,4 @@ sgx_types = { path = "../../../../deps/rust-sgx-sdk/sgx_types" }
 libc = "0.2"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]


### PR DESCRIPTION
1. When including the header file in C++ project, the linker
cannot find the functions.
2. Add the staticlib building.

Signed-off-by: yuanwu <yuan.wu@intel.com>