### PR TITLE
doc(demos/PyTorch): fix wrong message in README

### DIFF
--- a/demos/pytorch/README.md
+++ b/demos/pytorch/README.md
@@ -18,15 +18,14 @@ docker pull occlum/occlum:0.23.0-ubuntu18.04
 docker run -it --name=pythonDemo --device /dev/sgx/enclave occlum/occlum:0.23.0-ubuntu18.04 bash
 ```
 
-Step 2 (on the host): Download miniconda and install python to prefix position.
+Step 2 (in the Occlum container): Download miniconda and install python to prefix position.
 ```
-cd /root/occlum/demos/pytorch
+cd /root/demos/pytorch
 bash ./install_python_with_conda.sh
 ```
 
-Step 3 (on the host): Run the sample code on Occlum
+Step 3 (in the Occlum container): Run the sample code on Occlum
 ```
-cd /root/occlum/demos/pytorch
+cd /root/demos/pytorch
 bash ./run_pytorch_on_occlum.sh
 ```
-


### PR DESCRIPTION
There are two errors in PyTorch demo's README.md

- Step 2 and 3 should be executed inside the container, not on host.
- The demo's dir is ` /root/demos/pytorch`, not ` /root/occlum/demos/pytorch`