### PR TITLE
BUG: incompatible timespec convertion from rust to c

### DIFF
--- a/src/libos/src/fs/hostfs.rs
+++ b/src/libos/src/fs/hostfs.rs
@@ -343,15 +343,15 @@ impl IntoFsMetadata for fs::Metadata {
             blocks: self.st_blocks() as usize,
             atime: Timespec {
                 sec: self.st_atime(),
-                nsec: self.st_atime_nsec() as i32,
+                nsec: self.st_atime_nsec(),
             },
             mtime: Timespec {
                 sec: self.st_mtime(),
-                nsec: self.st_mtime_nsec() as i32,
+                nsec: self.st_mtime_nsec(),
             },
             ctime: Timespec {
                 sec: self.st_ctime(),
-                nsec: self.st_ctime_nsec() as i32,
+                nsec: self.st_ctime_nsec(),
             },
             type_: match self.st_mode() & 0xf000 {
                 libc::S_IFCHR => FileType::CharDevice,

--- a/src/libos/src/time/mod.rs
+++ b/src/libos/src/time/mod.rs
@@ -248,7 +248,7 @@ impl TimeProvider for OcclumTimeProvider {
         let time = do_gettimeofday();
         Timespec {
             sec: time.sec,
-            nsec: time.usec as i32 * 1000,
+            nsec: time.usec * 1000,
         }
     }
 }


### PR DESCRIPTION
Cannot get correct time when running java/c program in occlum due to incompatible timespec convertion from Rust to C. Actually, the ability of getting correct time is very important for some applications, for example, using JAVA FileLock which repetitively check file last-change time. This bug would make those application rush to error.
The bug is caused by incompatible timespec conversion in Rust ({i64, i32}) and C ({long, long}). When C program invokes a Rust lib to get one variable (e.g., info) including  timespec-type value (info.atime), the result in C  is not same to that generated in Rust.
Remember to check [#40](https://github.com/occlum/sefs/pull/40#issue-1098863814) which also includes one sample code.
In additional, thanks to @liqinggd for his generous help.