### PR TITLE
[tools]Support chroot inside copy_bom

### DIFF
--- a/tools/copy_bom/README.md
+++ b/tools/copy_bom/README.md
@@ -31,6 +31,7 @@ All dependencies will be copied to the corresponding directory in root directory
 ### flags
 - -i, --include-dir: This flag is used to indicate which directory to find included bom files. This flag can be set multiple times. If the `include-dir` is set as a relative path, it is a path relative to the current path where you run the `copy_bom` command. 
 - -h, --help: print help message
+- --rootfs: This flag is used to indicate the rootfs directory. If this flag is set, copy_bom will require sudo privilege to run.
 
 # About the `occlum_elf_loader.config` file
 

--- a/tools/copy_bom/src/main.rs
+++ b/tools/copy_bom/src/main.rs
@@ -30,6 +30,9 @@ struct CopyBomOption {
     /// Set the paths where to find included bom files
     #[structopt(long = "include-dir")]
     included_dirs: Vec<String>,
+    /// Set the rootfs where to do file operations. Bom file should not be poot in rootfs.
+    #[structopt(long = "rootfs")]
+    rootfs: Option<String>,
 }
 
 impl CopyBomOption {
@@ -39,9 +42,10 @@ impl CopyBomOption {
             root_dir,
             dry_run,
             included_dirs,
+            rootfs,
         } = self;
         let image = Bom::from_yaml_file(bom_file);
-        image.manage_top_bom(bom_file, root_dir, *dry_run, included_dirs);
+        image.manage_top_bom(bom_file, root_dir, *dry_run, included_dirs, rootfs);
     }
 }
 


### PR DESCRIPTION
Support executing file operations inside rootfs with `copy_bom`. The example usage is `copy_bom -f XXX.yaml --rootfs YYY`, then file operations will be executed like `chroot YYY cp a b`. If rootfs is set, `copy_bom` will require sudo privilege since `chroot` requires it.