### PR TITLE
[tools]Support setting library path for copy_bom

### DIFF
--- a/tools/copy_bom/README.md
+++ b/tools/copy_bom/README.md
@@ -27,6 +27,7 @@ All dependencies will be copied to the corresponding directory in root directory
 
 ### options
 - dry run mode: pass an option `--dry-run` to `copy_bom` will enable dry run mode. Dry run mode will output all file oprations in log but does not do real oprations. It is useul to check whether `copy_bom` performs as expected before doing real operations.
+- lib-path: pass option `--lib-path <lib-path>`, this path will guide `copy_bom` where to find libraries.  If this option is set, `copy_bom` behaves the same if the path is added to `occlum_elf_loader.config`.
 
 ### flags
 - -i, --include-dir: This flag is used to indicate which directory to find included bom files. This flag can be set multiple times. If the `include-dir` is set as a relative path, it is a path relative to the current path where you run the `copy_bom` command. 

--- a/tools/copy_bom/src/main.rs
+++ b/tools/copy_bom/src/main.rs
@@ -11,6 +11,7 @@ use bom::Bom;
 use env_logger::Env;
 use structopt::StructOpt;
 use util::check_rsync;
+use util::set_aditional_lib_path;
 
 mod bom;
 mod error;
@@ -31,6 +32,9 @@ struct CopyBomOption {
     /// Set the paths where to find included bom files
     #[structopt(long = "include-dir")]
     included_dirs: Vec<String>,
+    /// Set the paths where to find dependent libraries
+    #[structopt(long = "lib-path")]
+    lib_path: Option<String>,
 }
 
 impl CopyBomOption {
@@ -40,7 +44,9 @@ impl CopyBomOption {
             root_dir,
             dry_run,
             included_dirs,
+            lib_path,
         } = self;
+        set_aditional_lib_path(lib_path);
         let image = Bom::from_yaml_file(bom_file);
         image.manage_top_bom(bom_file, root_dir, *dry_run, included_dirs);
     }


### PR DESCRIPTION
copy_bom can accept command line option `lib-path` to determine where to find dependent libraries