### PR TITLE
Remove Linux-ltp getdtablesize01 syscalls test

### DIFF
--- a/demos/linux-ltp/syscalls-occlum
+++ b/demos/linux-ltp/syscalls-occlum
@@ -429,8 +429,6 @@ getdents02 getdents02
 
 getdomainname01 getdomainname01
 
-getdtablesize01 getdtablesize01
-
 getegid01 getegid01
 getegid01_16 getegid01_16
 getegid02 getegid02


### PR DESCRIPTION
The Linux-ltp getdtablesize01 opens "/etc/hosts" file as many, which run out of memory if without limitations. Now I have implemented rlimit_nofile limitations for opening files, but it would cause more failure in gvisor tests. The reasons have been listed in the [issue865](https://github.com/occlum/occlum/issues/865). Therefore, for ensuring CI test integrity as quickly, the Linux-ltp getdtablesize01 test is removed.