### PR TITLE
Runtime boot

### DIFF
--- a/demos/runtime_boot/README.md
+++ b/demos/runtime_boot/README.md
@@ -1,0 +1,38 @@
+# Runtime boot pre-generated UnionFS image
+
+Generally, every Occlum instance has to pass the `Occlum build` process.
+In some scenarios, mount and boot a pre-generated UnionFS image without `Occlum build` is a good feature. This demo introduces a way to runtime boot a BASH demo.
+
+## Flow
+
+### First, build a [`BASH`](../bash) Occlum instance
+
+The later step will use the image content to generate UnionFS image.
+
+### Build and start a [`gen_rootfs`](./gen_rootfs) Occlum instance
+
+This `gen_rootfs` mounts a empty UnionFS, copy the BASH Occlum image content to mount point, unmount the UnionFS. It generates an encrypted UnionFS image containing the BASH image content. The **key** used in this demo is `"c7-32-b3-ed-44-df-ec-7b-25-2d-9a-32-38-8d-58-61"`.
+
+### Build customized [`init`](./init)
+
+Occlum default init calls syscall (363) `MountRootFS` for Occlum instance by `Occlum build`.
+This customized init calls syscall (364) `MountRuntimeRootFS` to mount encrypted UnionFS image to boot.
+
+### Build a boot template Occlum instance
+
+This template uses the customized init. The RootFS image is not important, which will be replaced during boot.
+
+### Add `Occlum.json.unprotected` to boot template Occlum instance
+
+The `Occlum.json.unprotected` is the same with `Occlum.json` except the `entry_points` and image layer `source` is updated to adapt to the encrypted BASH UnionFS image.
+
+All above steps could be done with one [`script`](./build_content.sh).
+
+After running the script, runtime boot BASH could be done as below even if the default RootFS image has no BASH function.
+```
+# cd boot_instance
+# occlum run /bin/occlum_bash_test.sh
+```
+
+
+

--- a/demos/runtime_boot/boot_template.yaml
+++ b/demos/runtime_boot/boot_template.yaml
@@ -1,0 +1,9 @@
+includes:
+  - base.yaml
+targets:
+  - target: /bin
+    copy:
+      - files:
+        - /usr/bin/hostname
+
+  

--- a/demos/runtime_boot/build_content.sh
+++ b/demos/runtime_boot/build_content.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -e
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" >/dev/null 2>&1 && pwd )"
+
+export BASH_DEMO_DIR="${script_dir}/../bash"
+export INIT_DIR="${script_dir}/init"
+
+UNIONFS_DIR="${script_dir}/gen_rootfs_instance/mnt_unionfs"
+ENCRIP_KEY="c7-32-b3-ed-44-df-ec-7b-25-2d-9a-32-38-8d-58-61"
+
+function build_bash_demo()
+{
+    pushd ${BASH_DEMO_DIR}
+    rm -rf occlum_instance && occlum new occlum_instance
+
+    cd occlum_instance
+    rm -rf image
+    copy_bom -f ../bash.yaml --root image --include-dir /opt/occlum/etc/template
+
+    new_json="$(jq '.resource_limits.user_space_size = "600MB" |
+                    .resource_limits.kernel_space_stack_size ="2MB"	' Occlum.json)" && \
+    echo "${new_json}" > Occlum.json
+
+    occlum build
+    popd
+}
+
+function build_init()
+{
+    pushd ${INIT_DIR}
+    occlum-cargo clean
+    occlum-cargo build --release
+    popd
+}
+
+function build_and_gen_rootfs()
+{
+    pushd gen_rootfs
+    cargo build
+    popd
+
+    # initialize occlum workspace
+    rm -rf gen_rootfs_instance && occlum new gen_rootfs_instance
+    pushd gen_rootfs_instance
+
+    new_json="$(jq '.resource_limits.user_space_size = "1000MB" |
+                .resource_limits.kernel_space_heap_size= "512MB" |
+                .resource_limits.kernel_space_stack_size= "16MB" ' Occlum.json)" && \
+    echo "${new_json}" > Occlum.json
+
+    rm -rf image
+    copy_bom -f ../gen_rootfs.yaml --root image --include-dir /opt/occlum/etc/template
+
+    occlum build
+
+    mkdir -p mnt_unionfs/lower
+    mkdir -p mnt_unionfs/upper
+    mkdir rootfs
+    cp -rf ${BASH_DEMO_DIR}/occlum_instance/image/* rootfs/
+
+    occlum run /bin/gen_rootfs ${ENCRIP_KEY}
+
+    popd
+}
+
+function build_boot_template()
+{
+    rm -rf boot_instance && occlum new boot_instance
+    pushd boot_instance
+
+    new_json="$(jq '.resource_limits.user_space_size = "600MB" |
+                    .resource_limits.kernel_space_stack_size ="2MB"	' Occlum.json)" && \
+    echo "${new_json}" > Occlum.json
+
+    rm -rf image
+    copy_bom -f ../boot_template.yaml --root image --include-dir /opt/occlum/etc/template
+
+    # Update init
+    rm -rf initfs
+    copy_bom -f ../init.yaml --root initfs --include-dir /opt/occlum/etc/template 
+
+    occlum build
+    popd
+}
+
+function update_boot_instance()
+{
+    unionfs_upperlayer=${1}
+    entry_point=${2:-"/bin"}
+    
+    pushd boot_instance/build
+
+    # Remove MAC
+    jq 'del(.. | .MAC?)' Occlum.json > Occlum.json.unprotected
+    # Add index for image layer
+    new_json="$(jq '.mount[0].options.layers[0].options.index = 1' Occlum.json.unprotected)" && \
+    echo "${new_json}" > Occlum.json.unprotected
+
+    # Set image layer source
+    new_json="$(jq --arg source ${unionfs_upperlayer} \
+        '.mount[0].options.layers[0].source = $source' Occlum.json.unprotected)" && \
+    echo "${new_json}" > Occlum.json.unprotected
+ 
+    # Update entrypoint
+    new_json="$(jq --arg entry ${entry_point} \
+        '.entry_points = [ $entry ]' Occlum.json.unprotected)" && \
+    echo "${new_json}" > Occlum.json.unprotected
+
+    popd
+}
+
+build_bash_demo
+build_and_gen_rootfs
+build_init
+build_boot_template
+update_boot_instance ${UNIONFS_DIR}/upper /bin

--- a/demos/runtime_boot/gen_rootfs.yaml
+++ b/demos/runtime_boot/gen_rootfs.yaml
@@ -1,0 +1,9 @@
+includes:
+  - base.yaml
+targets:
+  - target: /bin
+    copy:
+      - files:
+        - ../gen_rootfs/target/debug/gen_rootfs
+
+  

--- a/demos/runtime_boot/gen_rootfs/Cargo.toml
+++ b/demos/runtime_boot/gen_rootfs/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "gen_rootfs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc = "0.2"
+nix = "0.23.0"
+fs_extra = "1.2"

--- a/demos/runtime_boot/gen_rootfs/src/main.rs
+++ b/demos/runtime_boot/gen_rootfs/src/main.rs
@@ -1,0 +1,74 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+use nix::mount::{mount, umount, MsFlags};
+use fs_extra::dir::{copy, CopyOptions};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    println!("{:?}", args);
+    fs::create_dir("/mount").unwrap();
+
+    let fs_type = "unionfs";
+    let mount_path = Path::new("/mount");
+    let source = Path::new("unionfs");
+    let flags = MsFlags::empty();
+    let key = &args[1];
+    let options = format!(
+        "lowerdir={},upperdir={},key={}",
+        "./mnt_unionfs/lower",
+        "./mnt_unionfs/upper",
+        key
+    );
+
+    println!("{:#?} {:#?} {:#?} {:#?} {:#?}", source, mount_path, fs_type, flags, options.as_str());
+    mount(
+        Some(source),
+        mount_path,
+        Some(fs_type),
+        flags,
+        Some(options.as_str()),
+    ).unwrap();
+
+    println!("Copy rootfs content to /mount");
+    let copy_options = CopyOptions::new();
+    let paths = fs::read_dir("/host/rootfs").unwrap();
+
+    for entry in paths {
+        let path = entry.unwrap().path();
+        println!("Name: {}", path.display());
+        copy(path, "/mount", &copy_options).unwrap();
+    }
+    
+    println!("List directories in {:#?}", mount_path);
+    let paths = fs::read_dir("/mount").unwrap();
+
+    for path in paths {
+        println!("Name: {}", path.unwrap().path().display())
+    }
+
+    println!("Unmount {:#?}", mount_path);
+    umount(mount_path).unwrap();
+
+    println!("Do mount again");
+    fs::create_dir("/mount2").unwrap();
+    let mount_path = Path::new("/mount2");
+    println!("{:#?} {:#?} {:#?} {:#?} {:#?}", source, mount_path, fs_type, flags, options.as_str());
+    mount(
+        Some(source),
+        mount_path,
+        Some(fs_type),
+        flags,
+        Some(options.as_str()),
+    ).unwrap();
+
+    println!("List directories in {:#?}", mount_path);
+    let paths = fs::read_dir("/mount2").unwrap();
+
+    for path in paths {
+        println!("Name: {}", path.unwrap().path().display())
+    }
+
+    println!("Unmount {:#?}", mount_path);
+    umount(mount_path).unwrap();
+}

--- a/demos/runtime_boot/init.yaml
+++ b/demos/runtime_boot/init.yaml
@@ -1,0 +1,7 @@
+includes:
+  - base.yaml
+targets:
+  - target: /bin/
+    copy:
+      - files:
+        - ${INIT_DIR}/target/x86_64-unknown-linux-musl/release/init

--- a/demos/runtime_boot/init/Cargo.toml
+++ b/demos/runtime_boot/init/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "init"
+version = "0.0.1"
+authors = ["LI Qing geding.lq@antgroup.com"]
+edition = "2018"
+
+[dependencies]
+libc = "0.2.84"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/demos/runtime_boot/init/src/main.rs
+++ b/demos/runtime_boot/init/src/main.rs
@@ -1,0 +1,118 @@
+extern crate libc;
+extern crate serde;
+extern crate serde_json;
+
+use libc::syscall;
+use serde::Deserialize;
+
+use std::io::prelude::*;
+use std::error::Error;
+use std::fs::File;
+use std::io::{ErrorKind, Read};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Load the configuration from initfs
+    const IMAGE_CONFIG_FILE: &str = "/etc/image_config.json";
+    let image_config = load_config(IMAGE_CONFIG_FILE)?;
+
+    // Get the MAC of Occlum.json.protected file
+    // let occlum_json_mac = {
+    //     let mut mac: sgx_aes_gcm_128bit_tag_t = Default::default();
+    //     parse_str_to_bytes(&image_config.occlum_json_mac, &mut mac)?;
+    //     mac
+    // };
+    // let occlum_json_mac_ptr = &occlum_json_mac as *const sgx_aes_gcm_128bit_tag_t;
+
+    // Get the key of FS image if needed
+    // let key = match &image_config.image_type[..] {
+    //     "encrypted" => {
+    //         // TODO: Get the key through RA or LA
+    //         let mut file = File::create("/etc/image_key")?;
+    //         // Writes key.
+    //         file.write(b"c7-32-b3-ed-44-df-ec-7b-25-2d-9a-32-38-8d-58-61")?;
+
+    //         const IMAGE_KEY_FILE: &str = "/etc/image_key";
+    //         let key_str = load_key(IMAGE_KEY_FILE)?;
+    //         let mut key: sgx_key_128bit_t = Default::default();
+    //         parse_str_to_bytes(&key_str, &mut key)?;
+    //         Some(key)
+    //     }
+    //     "integrity-only" => None,
+    //     _ => unreachable!(),
+    // };
+
+    let key = {
+        // TODO: Get the key through RA or LA
+        let mut file = File::create("/etc/image_key")?;
+        // Writes key.
+        file.write(b"c7-32-b3-ed-44-df-ec-7b-25-2d-9a-32-38-8d-58-61")?;
+
+        const IMAGE_KEY_FILE: &str = "/etc/image_key";
+        let key_str = load_key(IMAGE_KEY_FILE)?;
+        let mut key: sgx_key_128bit_t = Default::default();
+        parse_str_to_bytes(&key_str, &mut key)?;
+        Some(key)
+    };
+
+    let key_ptr = key
+        .as_ref()
+        .map(|key| key as *const sgx_key_128bit_t)
+        .unwrap_or(std::ptr::null());
+
+    // Runtime Mount the Rootfs image
+    const SYS_MOUNT_FS: i64 = 364;
+    let ret = unsafe { syscall(SYS_MOUNT_FS, key_ptr) };
+    if ret < 0 {
+        return Err(Box::new(std::io::Error::last_os_error()));
+    }
+
+    Ok(())
+}
+
+#[allow(non_camel_case_types)]
+type sgx_key_128bit_t = [u8; 16];
+#[allow(non_camel_case_types)]
+type sgx_aes_gcm_128bit_tag_t = [u8; 16];
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct ImageConfig {
+    occlum_json_mac: String,
+    image_type: String,
+}
+
+fn load_config(config_path: &str) -> Result<ImageConfig, Box<dyn Error>> {
+    let mut config_file = File::open(config_path)?;
+    let config_json = {
+        let mut config_json = String::new();
+        config_file.read_to_string(&mut config_json)?;
+        config_json
+    };
+    let config: ImageConfig = serde_json::from_str(&config_json)?;
+    Ok(config)
+}
+
+fn load_key(key_path: &str) -> Result<String, Box<dyn Error>> {
+    let mut key_file = File::open(key_path)?;
+    let mut key = String::new();
+    key_file.read_to_string(&mut key)?;
+    Ok(key.trim_end_matches(|c| c == '\r' || c == '\n').to_string())
+}
+
+fn parse_str_to_bytes(arg_str: &str, bytes: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    let bytes_str_vec = {
+        let bytes_str_vec: Vec<&str> = arg_str.split('-').collect();
+        if bytes_str_vec.len() != bytes.len() {
+            return Err(Box::new(std::io::Error::new(
+                ErrorKind::InvalidData,
+                "The length or format of Key/MAC string is invalid",
+            )));
+        }
+        bytes_str_vec
+    };
+
+    for (byte_i, byte_str) in bytes_str_vec.iter().enumerate() {
+        bytes[byte_i] = u8::from_str_radix(byte_str, 16)?;
+    }
+    Ok(())
+}

--- a/src/libos/src/fs/rootfs.rs
+++ b/src/libos/src/fs/rootfs.rs
@@ -49,7 +49,7 @@ pub fn open_root_fs_according_to(
         .find(|m| {
             m.target == Path::new("/")
                 && m.type_ == ConfigMountFsType::TYPE_SEFS
-                && m.options.mac.is_some()
+                && (m.options.mac.is_some() || m.options.index == 1)
         })
         .ok_or_else(|| errno!(Errno::ENOENT, "the image SEFS in layers is not valid"))?;
     let root_image_sefs =
@@ -61,6 +61,7 @@ pub fn open_root_fs_according_to(
             m.target == Path::new("/")
                 && m.type_ == ConfigMountFsType::TYPE_SEFS
                 && m.options.mac.is_none()
+                && m.options.index == 0
         })
         .ok_or_else(|| errno!(Errno::ENOENT, "the container SEFS in layers is not valid"))?;
     let root_container_sefs =

--- a/src/libos/src/fs/syscalls.rs
+++ b/src/libos/src/fs/syscalls.rs
@@ -655,6 +655,20 @@ pub fn do_mount_rootfs(
     Ok(0)
 }
 
+pub fn do_mount_runtime_rootfs(key_ptr: *const sgx_key_128bit_t) -> Result<isize> {
+    let key = if key_ptr.is_null() {
+        None
+    } else {
+        Some(unsafe { key_ptr.read() })
+    };
+
+    let user_config_path =
+        unsafe { format!("{}{}", INSTANCE_DIR, "/build/Occlum.json.unprotected") };
+    let user_config = config::load_runtime_config(&user_config_path)?;
+    fs_ops::do_mount_rootfs(&user_config, &key)?;
+    Ok(0)
+}
+
 pub fn do_fallocate(fd: FileDesc, mode: u32, offset: off_t, len: off_t) -> Result<isize> {
     if offset < 0 || len <= 0 {
         return_errno!(

--- a/src/libos/src/syscall/mod.rs
+++ b/src/libos/src/syscall/mod.rs
@@ -27,12 +27,12 @@ use crate::fs::{
     do_fchown, do_fchownat, do_fcntl, do_fdatasync, do_flock, do_fstat, do_fstatat, do_fstatfs,
     do_fsync, do_ftruncate, do_futimesat, do_getcwd, do_getdents, do_getdents64, do_ioctl,
     do_lchown, do_link, do_linkat, do_lseek, do_lstat, do_mkdir, do_mkdirat, do_mount,
-    do_mount_rootfs, do_open, do_openat, do_pipe, do_pipe2, do_pread, do_pwrite, do_read,
-    do_readlink, do_readlinkat, do_readv, do_rename, do_renameat, do_rmdir, do_sendfile, do_stat,
-    do_statfs, do_symlink, do_symlinkat, do_sync, do_timerfd_create, do_timerfd_gettime,
-    do_timerfd_settime, do_truncate, do_umask, do_umount, do_unlink, do_unlinkat, do_utime,
-    do_utimensat, do_utimes, do_write, do_writev, iovec_t, utimbuf_t, AsTimer, File, FileDesc,
-    FileRef, HostStdioFds, Stat, Statfs,
+    do_mount_rootfs, do_mount_runtime_rootfs, do_open, do_openat, do_pipe, do_pipe2, do_pread,
+    do_pwrite, do_read, do_readlink, do_readlinkat, do_readv, do_rename, do_renameat, do_rmdir,
+    do_sendfile, do_stat, do_statfs, do_symlink, do_symlinkat, do_sync, do_timerfd_create,
+    do_timerfd_gettime, do_timerfd_settime, do_truncate, do_umask, do_umount, do_unlink,
+    do_unlinkat, do_utime, do_utimensat, do_utimes, do_write, do_writev, iovec_t, utimbuf_t,
+    AsTimer, File, FileDesc, FileRef, HostStdioFds, Stat, Statfs,
 };
 use crate::interrupt::{do_handle_interrupt, sgx_interrupt_info_t};
 use crate::misc::{resource_t, rlimit_t, sysinfo_t, utsname_t, RandFlags};
@@ -422,6 +422,7 @@ macro_rules! process_syscall_table_with_callback {
             (HandleException = 361) => do_handle_exception(info: *mut sgx_exception_info_t, fpregs: *mut FpRegs, context: *mut CpuContext),
             (HandleInterrupt = 362) => do_handle_interrupt(info: *mut sgx_interrupt_info_t, fpregs: *mut FpRegs, context: *mut CpuContext),
             (MountRootFS = 363) => do_mount_rootfs(key_ptr: *const sgx_key_128bit_t, occlum_json_mac_ptr: *const sgx_aes_gcm_128bit_tag_t),
+            (MountRuntimeRootFS = 364) => do_mount_runtime_rootfs(key_ptr: *const sgx_key_128bit_t),
         }
     };
 }


### PR DESCRIPTION
Mount and boot a pre-generated UnionFS image without `Occlum build`.
1. LibOS changes
- Add a new syscall (364) to runtime mount pre-generated UnionFS image.
- Assume 'Occlum.json.unproteced' instead of 'Occlum.json.proteced' to save the `entry_points` and image layer `source`.

2. Add a demo
-  Generate encrypted UnionFS image
- A customized init
- Boot template to finally mount and boot  encrypted UnionFS image