### PR TITLE
Deep copy host file

### DIFF
--- a/src/Enclave.edl
+++ b/src/Enclave.edl
@@ -32,6 +32,15 @@ enclave {
         uint32_t qe_identity_size;
     };
 
+    struct host_file_buffer {
+        [size=resolv_conf_buf_size]char *resolv_conf_buf;
+        uint32_t resolv_conf_buf_size;
+        [size=hosts_buf_size]char *hosts_buf;
+        uint32_t hosts_buf_size;
+        [size=hostname_buf_size]char *hostname_buf;
+        uint32_t hostname_buf_size;
+    };
+
     trusted {
         /*
          * Initialize the LibOS according to the specified attributes.
@@ -43,7 +52,10 @@ enclave {
          *      EINVAL - The value of an argument are invalid.
          */
 
-        public int occlum_ecall_init([in, string] const char* log_level, [in, string] const char* instance_dir, [in] const struct host_file_buffer* file_buffer);
+        public int occlum_ecall_init(
+            [in, string] const char* log_level, 
+            [in, string] const char* instance_dir, 
+            [in] const struct host_file_buffer* file_buffer);
         
         /*
          * Create a new LibOS process to do the task specified by the given 

--- a/src/libos/include/edl/occlum_edl_types.h
+++ b/src/libos/include/edl/occlum_edl_types.h
@@ -29,13 +29,6 @@ typedef struct itimerspec{
     struct _timespec it_value;
 } itimerspec_t;
 
-// The host_file_buffer struct includes /etc/resolv.conf, /etc/hosts and /etc/hostname buffer
-struct host_file_buffer {
-    const char* resolv_conf_buf;
-    const char* hosts_buf;
-    const char* hostname_buf;
-};
-
 #define FD_SETSIZE 1024
 typedef struct {
     unsigned long fds_bits[FD_SETSIZE / 8 / sizeof(long)];

--- a/src/libos/src/util/host_file_util.rs
+++ b/src/libos/src/util/host_file_util.rs
@@ -7,8 +7,11 @@ use std::str;
 #[repr(C)]
 pub struct host_file_buffer {
     pub resolv_conf_buf: *const c_char,
+    resolv_conf_buf_size: u32,
     pub hosts_buf: *const c_char,
+    hosts_buf_size: u32,
     pub hostname_buf: *const c_char,
+    hostname_buf_size: u32,
 }
 
 pub enum HostFile {

--- a/src/pal/include/occlum_pal_api.h
+++ b/src/pal/include/occlum_pal_api.h
@@ -93,10 +93,13 @@ struct occlum_pal_create_process_args {
     int *pid;
 };
 
-struct host_file_buffer {
-    const char *resolv_conf_buf;
-    const char *hosts_buf;
-    const char *hostname_buf;
+struct host_file_buffer_t {
+    char *resolv_conf_buf;
+    unsigned int resolv_conf_buf_size;
+    char *hosts_buf;
+    unsigned int hosts_buf_size;
+    char *hostname_buf;
+    unsigned int hostname_buf_size;
 };
 
 /*
@@ -164,7 +167,7 @@ int occlum_pal_kill(int pid, int sig);
  */
 int occlum_pal_destroy(void);
 
-void free_host_file_buffer(struct host_file_buffer file_buffer);
+void free_host_file_buffer_t(struct host_file_buffer_t file_buffer);
 
 #ifdef __cplusplus
 }

--- a/src/pal/src/pal_load_file.c
+++ b/src/pal/src/pal_load_file.c
@@ -1,24 +1,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "pal_log.h"
+#include "pal_load_file.h"
 
-char *pal_load_file_to_string(const char *filename) {
+void pal_load_file(const char *filename, load_file_t *load_file) {
     FILE *fp = fopen(filename, "rb");
 
     if (fp == NULL) {
         PAL_WARN("Warning: Failed to open file: %s", filename);
-        return NULL;
+        return;
     }
     fseek(fp, 0, SEEK_END);
     long fsize = ftell(fp);
+
     fseek(fp, 0, SEEK_SET);
-    char *file_buffer = malloc(fsize + 1);
-    if (file_buffer == NULL) {
+    load_file->buffer = malloc(fsize + 1);
+    if (load_file->buffer == NULL) {
         PAL_WARN("Warning: Failed to malloc buffer for file: %s", filename);
-        return NULL;
+        return;
     }
-    fread(file_buffer, 1, fsize, fp);
-    file_buffer[fsize] = '\0';
+    fread(load_file->buffer, 1, fsize, fp);
+    load_file->buffer[fsize] = '\0';
+    load_file->size = fsize + 1;
+
     fclose(fp);
-    return file_buffer;
 }

--- a/src/pal/src/pal_load_file.h
+++ b/src/pal/src/pal_load_file.h
@@ -1,6 +1,11 @@
 #ifndef __PAL_LOAD_FILE_H__
 #define __PAL_LOAD_FILE_H__
 
-char *pal_load_file_to_string(const char *filename);
+typedef struct {
+    unsigned int size;
+    char *buffer;
+} load_file_t;
+
+void pal_load_file(const char *filename, load_file_t *load_file);
 
 #endif /* __PAL_LOAD_FILE_H__ */


### PR DESCRIPTION
When parsing host files into enclave, the host_file_buffer is shadow copied from untrusted memory, which is unsafe. Thus, the parsing methods are changed to deep copy.