### PR TITLE
Fix chunk manager munmap range

### DIFF
--- a/src/libos/src/vm/vm_chunk_manager.rs
+++ b/src/libos/src/vm/vm_chunk_manager.rs
@@ -141,7 +141,9 @@ impl ChunkManager {
     }
 
     pub fn munmap_range(&mut self, range: VMRange) -> Result<()> {
-        let bound = range.start();
+        // The bound should be no smaller than the chunk range's start address.
+        let bound = range.start().max(self.range.start());
+
         let current_pid = current!().process().pid();
 
         // The cursor to iterate vmas that might intersect with munmap_range.


### PR DESCRIPTION
When the munmap range is bigger than the Multi-VMA chunk's range, the bound was wrong and the munmap would misbehave.