### PR TITLE
[hw_ci] Increase timeout of stress test

### DIFF
--- a/.github/workflows/hw_mode_test.yml
+++ b/.github/workflows/hw_mode_test.yml
@@ -918,7 +918,7 @@ jobs:
       run: docker stop ${{ env.CONTAINER_NAME }}
 
   Stress_test_with_musl:
-    timeout-minutes: 180
+    timeout-minutes: 360
     if: github.event_name == 'schedule'
     runs-on: ${{ matrix.self_runner }}
     strategy:
@@ -951,7 +951,7 @@ jobs:
 
 
   Stress_test_with_glibc:
-    timeout-minutes: 180
+    timeout-minutes: 360
     if: github.event_name == 'schedule'
     runs-on: ${{ matrix.self_runner }}
     strategy:


### PR DESCRIPTION
Fix stress test running exceed given timeout.
The `timeout` should be taken as variables rather fixed value but not supported for now. See https://github.com/orgs/github-community/discussions/10690