### PR TITLE
Fix pytorch demo CI

### DIFF
--- a/.github/workflows/demo_test.yml
+++ b/.github/workflows/demo_test.yml
@@ -271,18 +271,7 @@ jobs:
       run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/pytorch; ./install_python_with_conda.sh"
 
     - name: Run pytorch test
-      run: docker exec -d ${{ github.job }} bash -c "cd /root/occlum/demos/pytorch; SGX_MODE=SIM ./run_pytorch_on_occlum.sh 2>&1 | tee /root/occlum/log"
-
-    # FIXME: PyTorch can't exit normally in SIM mode
-    - name: Kill the container
-      run: |
-        sleep 360;
-        cat "$GITHUB_WORKSPACE/log";
-        if grep -q Done "$GITHUB_WORKSPACE/log"; then
-          docker stop ${{ github.job }}
-        else
-          exit 1
-        fi
+      run: docker exec ${{ github.job }} bash -c "cd /root/occlum/demos/pytorch; SGX_MODE=SIM ./run_pytorch_on_occlum.sh"
 
 
   Tensorflow_test:


### PR DESCRIPTION
The previous error is due to the early kill of the container.

Heavily tested here: https://github.com/jessehui/occlum/actions/runs/2634970852