### PR TITLE
Fix the issue about fsync on hostfs's dir

### DIFF
--- a/src/libos/src/fs/hostfs.rs
+++ b/src/libos/src/fs/hostfs.rs
@@ -125,16 +125,24 @@ impl INode for HNode {
     }
 
     fn sync_all(&self) -> Result<()> {
-        let mut guard = self.open_file()?;
-        let file = guard.as_mut().unwrap();
-        try_std!(file.sync_all());
+        if self.path.is_file() {
+            let mut guard = self.open_file()?;
+            let file = guard.as_mut().unwrap();
+            try_std!(file.sync_all());
+        } else {
+            warn!("no sync_all method about dir, do nothing");
+        }
         Ok(())
     }
 
     fn sync_data(&self) -> Result<()> {
-        let mut guard = self.open_file()?;
-        let file = guard.as_mut().unwrap();
-        try_std!(file.sync_data());
+        if self.path.is_file() {
+            let mut guard = self.open_file()?;
+            let file = guard.as_mut().unwrap();
+            try_std!(file.sync_data());
+        } else {
+            warn!("no sync_data method about dir, do nothing");
+        }
         Ok(())
     }
 

--- a/test/hostfs/main.c
+++ b/test/hostfs/main.c
@@ -213,6 +213,7 @@ static int test_truncate() {
 static int test_mkdir_then_rmdir() {
     const char *dir_path = "/host/hostfs_dir";
     struct stat stat_buf;
+    int dir_fd;
 
     if (mkdir(dir_path, 00775) < 0) {
         THROW_ERROR("failed to create the dir");
@@ -223,6 +224,16 @@ static int test_mkdir_then_rmdir() {
     if (!S_ISDIR(stat_buf.st_mode)) {
         THROW_ERROR("failed to check if it is dir");
     }
+
+    dir_fd = open(dir_path, O_RDONLY | O_DIRECTORY);
+    if (dir_fd < 0) {
+        THROW_ERROR("failed to open dir");
+    }
+
+    if (fsync(dir_fd) < 0) {
+        THROW_ERROR("failed to fsync dir");
+    }
+    close(dir_fd);
 
     if (rmdir(dir_path) < 0) {
         THROW_ERROR("failed to remove the created dir");


### PR DESCRIPTION
There are no sync methods about untrusted dir, so we do nothing.

This commit may fix the issue https://github.com/occlum/occlum/issues/936