### PR TITLE
Set the default pkru value at Occlum.json's parse

### DIFF
--- a/tools/gen_internal_conf/src/main.rs
+++ b/tools/gen_internal_conf/src/main.rs
@@ -453,6 +453,7 @@ struct OcclumMetadata {
     enable_kss: bool,
     family_id: OcclumMetaID,
     ext_prod_id: OcclumMetaID,
+    #[serde(default)]
     pkru: u32,
 }
 


### PR DESCRIPTION
`pkru` field has been introduced in the Occlum.json since Occlum 0.28.0. Users may encounter failure in `occlum build` if they use legacy Occlum.json, since there is no `pkru` field in it. To work around it, we specify the default value of `pkru` as 0 for its missing in Occlum.json. 