### PR TITLE
Add get_dcap_quote

### DIFF
--- a/demos/remote_attestation/dcap/c_app/dcap_c_test.c
+++ b/demos/remote_attestation/dcap/c_app/dcap_c_test.c
@@ -48,7 +48,7 @@ void dump_quote_info(sgx_quote3_t *p_quote)
     printf("\t0x%04x\n", p_rep_body->config_svn);
 }
 
-void main(int argc, char *args[]) {
+void main() {
     void *handle;
     uint32_t quote_size, supplemental_size;
     uint8_t *p_quote_buffer, *p_supplemental_buffer;
@@ -69,11 +69,7 @@ void main(int argc, char *args[]) {
     memset(p_quote_buffer, 0, quote_size);
 
     sgx_report_data_t report_data = { 0 };
-    char *data = "ppml";
-    if (args[1] != NULL && args[1] != "") {
-    	data = args[1];
-    }
-    printf("report data: %s\n", data);
+    char *data = "ioctl DCAP report data example";
     memcpy(report_data.d, data, strlen(data));
 
     // Get the Quote

--- a/demos/remote_attestation/dcap/dcap-ppml.yaml
+++ b/demos/remote_attestation/dcap/dcap-ppml.yaml
@@ -1,0 +1,15 @@
+includes:
+  - base.yaml
+# dcap
+targets:
+  # copy bins
+  - target: /bin
+    copy:
+      - files:
+        - /root/demos/remote_attestation/dcap/c_app/dcap_c_test
+  # copy lib
+  - target: /opt/occlum/glibc/lib
+    copy:
+      - files:
+        - /opt/occlum/toolchains/dcap_lib/glibc/libocclum_dcap.so.0.1.0
+

--- a/demos/remote_attestation/dcap/get_quote_on_ppml.sh
+++ b/demos/remote_attestation/dcap/get_quote_on_ppml.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+BLUE='\033[1;34m'
+NC='\033[0m'
+
+if [[ $1 == "musl" ]]; then
+    echo "*** Build and run musl-libc dcap demo ***"
+    bomfile="../dcap-musl.yaml"
+    CC=occlum-gcc
+    LD=occlum-ld
+    LIBPATH="/opt/occlum/toolchains/dcap_lib/musl"
+else
+    echo "*** Build and run glibc dcap demo ***"
+    bomfile="../dcap.yaml"
+    CC=gcc
+    LD=ld
+    LIBPATH="/opt/occlum/toolchains/dcap_lib/glibc"
+fi
+
+INCPATH="/opt/occlum/toolchains/dcap_lib/inc"
+
+CC=$CC LD=$LD LIBPATH=$LIBPATH make -C c_app clean
+CC=$CC LD=$LD LIBPATH=$LIBPATH INCPATH=$INCPATH make -C c_app

--- a/demos/remote_attestation/dcap/get_quote_on_ppml.sh
+++ b/demos/remote_attestation/dcap/get_quote_on_ppml.sh
@@ -6,13 +6,11 @@ NC='\033[0m'
 
 if [[ $1 == "musl" ]]; then
     echo "*** Build and run musl-libc dcap demo ***"
-    bomfile="../dcap-musl.yaml"
     CC=occlum-gcc
     LD=occlum-ld
     LIBPATH="/opt/occlum/toolchains/dcap_lib/musl"
 else
     echo "*** Build and run glibc dcap demo ***"
-    bomfile="../dcap.yaml"
     CC=gcc
     LD=ld
     LIBPATH="/opt/occlum/toolchains/dcap_lib/glibc"


### PR DESCRIPTION
When Applying EHSM remote attestation in occlum. Need to get dcap quote and send it to EHSM for attestation.
To write quote to a binary file，and then running PPML jar will read it and send it to attest.