### PR TITLE
[sefs] Configure larger cache size to improve pfs performance

### DIFF
--- a/src/libos/src/fs/sefs/mod.rs
+++ b/src/libos/src/fs/sefs/mod.rs
@@ -5,3 +5,7 @@ pub use self::sgx_uuid_provider::SgxUuidProvider;
 
 mod sgx_storage;
 mod sgx_uuid_provider;
+
+// Cache size of underlying SGX-PFS of SEFS
+// Default cache size: 0x1000 * 48
+const SEFS_CACHE_SIZE: u64 = 0x1000 * 256;

--- a/src/libos/src/fs/sefs/sgx_storage.rs
+++ b/src/libos/src/fs/sefs/sgx_storage.rs
@@ -97,9 +97,11 @@ impl Storage for SgxStorage {
             let file = match self.encrypt_mode {
                 EncryptMode::IntegrityOnly(_) => options.open_integrity_only(path)?,
                 EncryptMode::EncryptWithIntegrity(key, _) | EncryptMode::Encrypt(key) => {
-                    options.open_ex(path, &key)?
+                    options.open_with(path, Some(&key), Some(SEFS_CACHE_SIZE))?
                 }
-                EncryptMode::EncryptAutoKey => options.open(path)?,
+                EncryptMode::EncryptAutoKey => {
+                    options.open_with(path, None, Some(SEFS_CACHE_SIZE))?
+                }
             };
 
             // Check the MAC of the root file against the given root MAC of the storage
@@ -132,9 +134,11 @@ impl Storage for SgxStorage {
             let file = match self.encrypt_mode {
                 EncryptMode::IntegrityOnly(_) => options.open_integrity_only(path)?,
                 EncryptMode::EncryptWithIntegrity(key, _) | EncryptMode::Encrypt(key) => {
-                    options.open_ex(path, &key)?
+                    options.open_with(path, Some(&key), Some(SEFS_CACHE_SIZE))?
                 }
-                EncryptMode::EncryptAutoKey => options.open(path)?,
+                EncryptMode::EncryptAutoKey => {
+                    options.open_with(path, None, Some(SEFS_CACHE_SIZE))?
+                }
             };
             Ok(LockedFile(Arc::new(Mutex::new(file))))
         })?;


### PR DESCRIPTION
This PR configure **cache size** of underlying SGX-PFS of SEFS to **1MiB** (default 192KiB).

Larger cache size can acclerate file I/O of SEFS.
(20% ~ 70% reads/writes improvemenet according to FIO test)