### PR TITLE
[test] No need build Occlum to make test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -26,6 +26,9 @@ TESTS ?= env empty hello_world malloc mmap file fs_perms getpid spawn sched pipe
 # Benchmarks: need to be compiled and run by bench-% target
 BENCHES := spawn_and_exit_latency pipe_throughput unix_socket_throughput
 
+# Occlum bin path
+OCCLUM_BIN_PATH ?= $(BUILD_DIR)/bin
+
 # Top-level Makefile targets
 BUILD_TARGETS := $(TEST_DEPS) $(TESTS) $(BENCHES)
 TEST_TARGETS := $(TESTS:%=test-%)
@@ -54,7 +57,7 @@ prebuild:
 	@$(RM) -rf $(BUILD_DIR)/test
 	@mkdir -p $(BUILD_DIR)/test
 	@cd $(BUILD_DIR)/test && \
-		$(BUILD_DIR)/bin/occlum init
+		$(OCCLUM_BIN_PATH)/occlum init
 	@cp Occlum.json $(BUILD_DIR)/test/
 
 $(BUILD_TARGETS): %:
@@ -64,7 +67,7 @@ $(BUILD_TARGETS): %:
 
 postbuild:
 	@cd $(BUILD_DIR)/test && \
-		$(BUILD_DIR)/bin/occlum build -f
+		$(OCCLUM_BIN_PATH)/occlum build -f
 
 #############################################################################
 # Test targets
@@ -87,7 +90,7 @@ test-internal: build pretest $(TEST_TARGETS) posttest
 pretest:
 	@$(RM) $(PASS_LOG) $(FAIL_LOG)
 	@cd $(BUILD_DIR)/test && \
-		$(BUILD_DIR)/bin/occlum start
+		$(OCCLUM_BIN_PATH)/occlum start
 
 # Restart server if test failed
 $(TEST_TARGETS): test-%: %
@@ -103,14 +106,14 @@ $(TEST_TARGETS): test-%: %
 			$(ECHO) "$(RED)FAILED$(NO_COLOR)" ; \
 			$(ECHO) "$< FAILED $$i" >> $(FAIL_LOG) ; \
 			cd $(BUILD_DIR)/test && \
-			$(BUILD_DIR)/bin/occlum start ; \
+			$(OCCLUM_BIN_PATH)/occlum start ; \
 			cd -; \
 		fi ; \
 	done
 
 posttest:
 	@cd $(BUILD_DIR)/test && \
-		$(BUILD_DIR)/bin/occlum stop
+		$(OCCLUM_BIN_PATH)/occlum stop
 	@PASS_NUM=$(shell wc -l < $(PASS_LOG)); \
 		FAIL_NUM=$(shell wc -l < $(FAIL_LOG)); \
 		$(ECHO) "\nTotal:" ; \

--- a/test/test_common.mk
+++ b/test/test_common.mk
@@ -10,6 +10,9 @@ TEST_NAME := $(shell basename $(CUR_DIR))
 IMAGE_DIR := $(BUILD_DIR)/test/image
 BIN := $(IMAGE_DIR)/bin/$(TEST_NAME)
 
+# Occlum bin path
+OCCLUM_BIN_PATH ?= $(BUILD_DIR)/bin
+
 C_SRCS := $(wildcard *.c)
 C_OBJS := $(addprefix $(BUILD_DIR)/test/obj/$(TEST_NAME)/,$(C_SRCS:%.c=%.o))
 CXX_SRCS := $(wildcard *.cc)
@@ -72,7 +75,7 @@ $(BUILD_DIR)/test/obj/$(TEST_NAME)/%.o: %.cc
 
 test:
 	@cd $(BUILD_DIR)/test && \
-		$(EXTRA_ENV) $(BUILD_DIR)/bin/occlum exec /bin/$(TEST_NAME) $(BIN_ARGS)
+		$(EXTRA_ENV) $(OCCLUM_BIN_PATH)/occlum exec /bin/$(TEST_NAME) $(BIN_ARGS)
 
 test-native:
 	@LD_LIBRARY_PATH=/usr/local/occlum/lib cd $(IMAGE_DIR) && ./bin/$(TEST_NAME) $(BIN_ARGS)


### PR DESCRIPTION
In default, `make test` requires the Occlum build first.
It also provides an option that is to specify the path of Occlum binary.
`OCCLUM_BIN_PATH=/opt/occlum/build/bin make test`