### PR TITLE
Improve clock_gettime, stream socket and add MySQL demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -21,6 +21,7 @@ This set of demos shows how real-world apps can be easily run inside SGX enclave
 * [font](font/font_support_for_java): A demo of supporting font with Java.
 * [grpc](grpc/): A client and server communicating through [gRPC](https://grpc.io), containing [glibc-supported demo](grpc/grpc_glibc) and [musl-supported demo](grpc/grpc_musl).
 * [https_server](https_server/): A HTTPS file server based on [Mongoose Embedded Web Server Library](https://github.com/cesanta/mongoose).
+* [mysql](mysql/): A demo of [MySQL](https://www.mysql.com/).
 * [openvino](openvino/) A benchmark of [OpenVINO Inference Engine](https://docs.openvinotoolkit.org/2019_R3/_docs_IE_DG_inference_engine_intro.html).
 * [pytorch](pytorch/): A demo of [PyTorch](https://pytorch.org/).
 * [redis](redis/): A demo of [Redis](https://redis.io).

--- a/demos/mysql/.gitignore
+++ b/demos/mysql/.gitignore
@@ -1,0 +1,4 @@
+occlum_instance
+mysql_src
+boost*
+*tar*

--- a/demos/mysql/README.md
+++ b/demos/mysql/README.md
@@ -1,0 +1,28 @@
+# Run MySQL on Occlum
+
+[`MySQL`](https://www.mysql.com/) is a widely used open-source relational database management system (RDBMS).
+
+### Build and install
+```
+./dl_and_build_mysql.sh
+```
+This command downloads MySQL-8.0.31 source code and builds from it.
+When completed, all MySQL related binaries and tools are installed.
+
+### Run server and client
+
+#### Initialize and start the MySQL server
+```
+./run_mysql_server.sh
+```
+This command initializes and runs the server (using `mysqld`) in Occlum.
+When completed, the server starts to wait connections.
+
+#### Start the MySQL client and send simple queries
+```
+./run_mysql_client.sh
+```
+This command starts the client (using `mysql`) in Occlum and test basic query SQLs.
+
+The client can choose uds(unix domain socket) or TCP/IP network protocol to connect to server.
+More configuration can be tuned and applied in `my.cnf`.

--- a/demos/mysql/apply-mysql-to-occlum.patch
+++ b/demos/mysql/apply-mysql-to-occlum.patch
@@ -1,0 +1,28 @@
+--- mysql_src/mysys/my_rdtsc-origin.cc	2022-12-08 09:14:01.171126659 +0000
++++ mysql_src/mysys/my_rdtsc.cc	2022-12-08 09:08:52.016352814 +0000
+@@ -299,16 +299,16 @@
+ */
+ 
+ ulonglong my_timer_ticks(void) {
+-#if defined(HAVE_SYS_TIMES_H) && defined(HAVE_TIMES)
+-  {
+-    struct tms times_buf;
+-    return (ulonglong)times(&times_buf);
+-  }
+-#elif defined(_WIN32)
+-  return (ulonglong)GetTickCount();
+-#else
++// #if defined(HAVE_SYS_TIMES_H) && defined(HAVE_TIMES)
++//   {
++//     struct tms times_buf;
++//     return (ulonglong)times(&times_buf);
++//   }
++// #elif defined(_WIN32)
++//   return (ulonglong)GetTickCount();
++// #else
+   return 0;
+-#endif
++// #endif
+ }
+ 
+ /**

--- a/demos/mysql/dl_and_build_mysql.sh
+++ b/demos/mysql/dl_and_build_mysql.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+BLUE='\033[1;34m'
+NC='\033[0m'
+echo -e "${BLUE}Start installing dependencies.${NC}"
+
+# Prepare environment
+DEPS="libnuma-dev libboost-all-dev"
+
+apt-get update
+apt-get install -y ${DEPS}
+
+BOOST="boost_1_77_0"
+wget https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST}.tar.bz2
+tar --bzip2 -xf ${BOOST}.tar.bz2
+pushd ${BOOST}
+./bootstrap.sh --prefix=/usr --with-python=python3 &&
+./b2 stage -j4 threading=multi link=shared
+./b2 install threading=multi link=shared
+popd
+
+echo -e "${BLUE}Finish installing dependencies.${NC}"
+
+echo -e "${BLUE}Start building mysql from src.${NC}"
+
+# Download released tarball
+VERSION="8.0.31"
+TARBALL="mysql-${VERSION}.tar.gz"
+wget https://github.com/mysql/mysql-server/archive/refs/tags/${TARBALL}
+rm -rf mysql_src && mkdir mysql_src
+tar -xf ${TARBALL} -C mysql_src --strip-components 1
+
+# Make modification to
+# 1. Disable `times` syscall
+patch -s -p0 < apply-mysql-to-occlum.patch
+
+# Build and install
+pushd mysql_src
+mkdir bld && cd bld
+
+cmake -j$(nproc) .. -DCMAKE_CXX_FLAGS="-fpic -pie" -DCMAKE_C_FLAGS="-fpic -pie"
+
+CC="-fpic -pie" CXX="-fpic -pie" make -j$(nproc)
+
+make install -j$(nproc)
+cd ..
+
+echo -e "${BLUE}Finish building mysql from src.${NC}"
+popd

--- a/demos/mysql/my.cnf
+++ b/demos/mysql/my.cnf
@@ -1,0 +1,19 @@
+# MySQL configure file
+
+[client]
+socket              =   /tmp/mysql.sock
+port                =   3306
+bind-address        =   127.0.0.1
+
+[mysqld]
+socket              =   /tmp/mysql.sock
+port                =   3306
+bind-address        =   127.0.0.1
+skip-networking     =   0
+skip_ssl            =   0
+mysqlx              =   0
+wait_timeout        =   60
+interactive_timeout =   120
+
+[mysql]
+connect_timeout     =   2

--- a/demos/mysql/mysql.yaml
+++ b/demos/mysql/mysql.yaml
@@ -1,0 +1,34 @@
+includes:
+  - base.yaml
+# mysql
+targets:
+  # copy bins
+  - target: /bin
+    copy:
+      - files:
+        # server tools
+        - /usr/local/mysql/bin/mysqld
+        # client tools
+        - /usr/local/mysql/bin/mysql
+        - /usr/local/mysql/bin/mysqladmin
+        - /usr/local/mysql/bin/mysqlshow
+  - target: /etc
+    copy:
+      - files:
+        - ../my.cnf
+  - target: /etc
+    copy:
+      - files:
+        - /etc/localtime
+  - target: /opt/occlum/glibc/etc
+    copy:
+      - files:
+        - /etc/localtime
+  - target: /opt/occlum/glibc/lib
+    copy:
+      - files:
+        - /usr/local/mysql/lib/mysqlrouter/private/libprotobuf-lite.so.3.19.4
+  - target: /
+    copy:
+      - files:
+        - /usr/local/mysql/bin/mysqld

--- a/demos/mysql/run_mysql_client.sh
+++ b/demos/mysql/run_mysql_client.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+MYSQL=mysql
+MYSQLSHOW=mysqlshow
+MYSQLADMIN=mysqladmin
+
+# Need to wait until server is ready
+echo -e "${GREEN}Need to wait mysql server to start${NC}"
+
+pushd occlum_instance
+
+SUFFIX="-h 127.0.0.1 -P 3306"
+echo -e "${GREEN}Run mysql client on Occlum${NC}"
+
+# Client on Occlum (TCP/IP)
+occlum exec /bin/${MYSQLADMIN} version ${SUFFIX}
+
+occlum exec /bin/${MYSQLSHOW} ${SUFFIX}
+
+occlum exec /bin/${MYSQL} -e "SELECT User, Host, plugin FROM mysql.user" ${SUFFIX}
+
+echo -e "${GREEN}Run mysql client on host${NC}"
+
+# Client on host (TCP/IP)
+/usr/local/mysql/bin/${MYSQLADMIN} version ${SUFFIX}
+
+/usr/local/mysql/bin/${MYSQLSHOW} ${SUFFIX}
+
+/usr/local/mysql/bin/${MYSQL} -e "SELECT User, Host, plugin FROM mysql.user" ${SUFFIX}
+
+occlum stop
+
+popd

--- a/demos/mysql/run_mysql_server.sh
+++ b/demos/mysql/run_mysql_server.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+bomfile=${SCRIPT_DIR}/mysql.yaml
+
+MYSQL=mysql
+MYSQLD=mysqld
+
+# 1. Init Occlum instance
+rm -rf occlum_instance && occlum new occlum_instance
+pushd occlum_instance
+
+yq '.resource_limits.user_space_size = "8000MB" |
+    .resource_limits.kernel_space_heap_size ="1000MB" ' -i Occlum.yaml
+
+# 2. Copy files into Occlum instance and build
+rm -rf image
+copy_bom -f $bomfile --root image --include-dir /opt/occlum/etc/template
+
+occlum build
+
+# 3. Run the program
+echo -e "${GREEN}Run mysql server (mysqld) on Occlum${NC}"
+
+occlum start
+
+echo -e "${GREEN}mysql server initialize${NC}"
+
+occlum exec /bin/${MYSQLD} --initialize-insecure --user=root
+
+echo -e "${GREEN}mysql server start${NC}"
+
+occlum exec /bin/${MYSQLD} --user=root
+
+popd

--- a/src/libos/crates/vdso-time/src/lib.rs
+++ b/src/libos/crates/vdso-time/src/lib.rs
@@ -269,6 +269,7 @@ impl Vdso {
             ClockId::CLOCK_REALTIME_COARSE | ClockId::CLOCK_MONOTONIC_COARSE => {
                 self.do_coarse(ClockSource::CS_HRES_COARSE, clockid)
             }
+            // TODO: support CLOCK_PROCESS_CPUTIME_ID and CLOCK_THREAD_CPUTIME_ID.
             _ => return_errno!(EINVAL, "Unsupported clockid in do_clock_gettime()"),
         }
     }
@@ -284,6 +285,7 @@ impl Vdso {
             ClockId::CLOCK_REALTIME_COARSE | ClockId::CLOCK_MONOTONIC_COARSE => self
                 .coarse_resolution
                 .ok_or(errno!(EOPNOTSUPP, "coarse_resolution is none")),
+            // TODO: support CLOCK_PROCESS_CPUTIME_ID and CLOCK_THREAD_CPUTIME_ID.
             _ => return_errno!(EINVAL, "Unsupported clockid in do_clock_getres()"),
         }
     }

--- a/src/libos/src/time/mod.rs
+++ b/src/libos/src/time/mod.rs
@@ -147,13 +147,6 @@ impl timespec_t {
 pub type clockid_t = i32;
 
 pub fn do_clock_gettime(clockid: ClockId) -> Result<timespec_t> {
-    // TODO: support CLOCK_PROCESS_CPUTIME_ID and CLOCK_THREAD_CPUTIME_ID.
-    if clockid == ClockId::CLOCK_PROCESS_CPUTIME_ID || clockid == ClockId::CLOCK_THREAD_CPUTIME_ID {
-        return_errno!(
-            EINVAL,
-            "Not support CLOCK_PROCESS_CPUTIME_ID or CLOCK_THREAD_CPUTIME_ID"
-        );
-    }
     let tv = timespec_t::from(vdso_time::clock_gettime(clockid).unwrap());
     tv.validate()
         .expect("clock_gettime returned invalid timespec");


### PR DESCRIPTION
This PR includes:

1. Workaround `CLOCK_PROCESS_CPUTIME_ID` and `CLOCK_THREAD_CPUTIME_ID` in `clock_gettime()`. The syscall with either these two flags would end up calling `vdso_ocall_clock_gettime()`.
2. Improve `ioctl()` in stream socket: Refine state transfer.
3. Add MySQL to demo list.