### PR TITLE
Improve benchmark ci and hw ci

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,167 @@
+name: Benchmarks Test
+# Currently this workflow is only used for running benchmarks test on schedule on branch 1.0.0-preview
+
+on:
+  schedule:
+    # Schedule to run on Wed,Sat at 10PM UTC (6AM CST)
+    - cron:  '0 22 * * 3,6'
+
+jobs:
+  Sysbench_Test:
+    timeout-minutes: 40
+    runs-on: ${{ matrix.self_runner }}
+    strategy:
+      matrix:
+        self_runner: [[self-hosted, SGX2-HW, benchmark]]
+
+    steps:
+    - name: Clean before running
+      run: |
+        sudo chown -R ${{ secrets.CI_ADMIN }} "${{ github.workspace }}"
+
+    - uses: AutoModality/action-clean@v1
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        ref: 1.0.0-preview
+
+    - uses: ./.github/workflows/composite_action/hw
+      with:
+        container-name: ${{ github.job }}
+        build-envs: 'OCCLUM_RELEASE_BUILD=1'
+
+    - name: Run sysbench download and build
+      run: docker exec ${{ env.CONTAINER_NAME }} bash -c "cd /root/occlum/demos/benchmarks/sysbench && ./sysbench.sh 120"
+
+    - name: Copy result
+      run: docker cp ${{ env.CONTAINER_NAME }}:/root/occlum/demos/benchmarks/sysbench/result.json .
+
+    # Run `github-action-benchmark` action
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Sysbench Benchmark
+        # What benchmark tool the output.txt came from
+        tool: 'customSmallerIsBetter'
+        # Where the output from the benchmark tool is stored
+        output-file-path: result.json
+        # Path to directory which contains benchmark files on GitHub pages branch
+        benchmark-data-dir-path: 'dev/benchmarks'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'
+        comment-on-alert: true
+        # Workflow will fail when an alert happens
+        fail-on-alert: true
+    - name: Clean the environment
+      if: ${{ always() }}
+      run: docker stop ${{ env.CONTAINER_NAME }}
+
+  Iperf3_Test:
+    timeout-minutes: 40
+    runs-on: ${{ matrix.self_runner }}
+    strategy:
+      matrix:
+        self_runner: [[self-hosted, SGX2-HW, benchmark]]
+
+    steps:
+    - name: Clean before running
+      run: |
+        sudo chown -R ${{ secrets.CI_ADMIN }} "${{ github.workspace }}"
+
+    - uses: AutoModality/action-clean@v1
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        ref: 1.0.0-preview
+
+    - uses: ./.github/workflows/composite_action/hw
+      with:
+        container-name: ${{ github.job }}
+        build-envs: 'OCCLUM_RELEASE_BUILD=1'
+
+    - name: Run iperf3 download and build
+      run: docker exec ${{ env.CONTAINER_NAME }} bash -c "cd /root/occlum/demos/benchmarks/iperf3 && ./iperf3.sh 120"
+
+    - name: Copy result
+      run: docker cp ${{ env.CONTAINER_NAME }}:/root/occlum/demos/benchmarks/iperf3/result.json .
+
+    # Run `github-action-benchmark` action
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Iperf3 Benchmark
+        # What benchmark tool the output.txt came from
+        tool: 'customBiggerIsBetter '
+        # Where the output from the benchmark tool is stored
+        output-file-path: result.json
+        # Path to directory which contains benchmark files on GitHub pages branch
+        benchmark-data-dir-path: 'dev/benchmarks'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'
+        comment-on-alert: true
+        # Workflow will fail when an alert happens
+        fail-on-alert: true
+    - name: Clean the environment
+      if: ${{ always() }}
+      run: docker stop ${{ env.CONTAINER_NAME }}
+
+  FIO_Test:
+    timeout-minutes: 60
+    runs-on: ${{ matrix.self_runner }}
+    strategy:
+      matrix:
+        self_runner: [[self-hosted, SGX2-HW, benchmark]]
+
+    steps:
+    - name: Clean before running
+      run: |
+        sudo chown -R ${{ secrets.CI_ADMIN }} "${{ github.workspace }}"
+
+    - uses: AutoModality/action-clean@v1
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        ref: 1.0.0-preview
+
+    - uses: ./.github/workflows/composite_action/hw
+      with:
+        container-name: ${{ github.job }}
+        build-envs: 'OCCLUM_RELEASE_BUILD=1'
+
+    - name: Run fio download and build
+      run: docker exec ${{ env.CONTAINER_NAME }} bash -c "cd /root/occlum/demos/benchmarks/fio && ./fio_microbench.sh"
+
+    - name: Copy result
+      run: docker cp ${{ env.CONTAINER_NAME }}:/root/occlum/demos/benchmarks/fio/result.json .
+
+    # Run `github-action-benchmark` action
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: FIO Benchmark
+        # What benchmark tool the output.txt came from
+        tool: 'customBiggerIsBetter'
+        # Where the output from the benchmark tool is stored
+        output-file-path: result.json
+        # Path to directory which contains benchmark files on GitHub pages branch
+        benchmark-data-dir-path: 'dev/benchmarks'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'
+        comment-on-alert: true
+        # Workflow will fail when an alert happens
+        fail-on-alert: true
+    - name: Clean the environment
+      if: ${{ always() }}
+      run: docker stop ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/hw_mode_test.yml
+++ b/.github/workflows/hw_mode_test.yml
@@ -6,12 +6,12 @@ on:
   pull_request_target:
     types: labeled
   schedule:
-  # Schedule to run everyday at 6PM UTC (2AM CST)
-    - cron:  '0 18 * * *'
+  # Schedule to run on Tue,Fri at 6PM UTC (2AM CST)
+    - cron:  '0 18 * * 2,5'
 
 env:
   nap_time: 60
-  repeat_times: 500  # Stress test repeat times
+  repeat_times: 250  # Stress test repeat times
 
 # Cancel previous running jobs on push or pull request
 concurrency:
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   Make-test-on-ubuntu:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -35,7 +35,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -67,7 +67,7 @@ jobs:
 
   C_cpp_rust_golang_embedded_mode_support_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -81,7 +81,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -162,7 +162,7 @@ jobs:
 
   Java_support_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -176,7 +176,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -212,7 +212,7 @@ jobs:
 
   Bazel_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -226,7 +226,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -264,7 +264,7 @@ jobs:
 
   Fish_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -278,7 +278,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -311,7 +311,7 @@ jobs:
 
   Xgboost_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -325,7 +325,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -358,7 +358,7 @@ jobs:
 
   Sqlite_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -372,7 +372,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -402,7 +402,7 @@ jobs:
 
   Python_musl_support_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -416,7 +416,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -473,7 +473,7 @@ jobs:
 
   Openvino_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -487,7 +487,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -541,7 +541,7 @@ jobs:
 
   Grpc_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -555,7 +555,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -631,7 +631,7 @@ jobs:
 
   Gvisor_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -645,7 +645,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -739,7 +739,7 @@ jobs:
 
   Test_deb_deploy:
     timeout-minutes: 180
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'schedule'
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -753,7 +753,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: false
@@ -780,7 +780,7 @@ jobs:
 # Tensorflow_serving requires binary tensorflow_serving PIC, here we compile tensorflow_model_server before workflow
   Tensorflow_serving_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -795,7 +795,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -860,7 +860,7 @@ jobs:
 
   Remote_attestation_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -874,7 +874,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -900,7 +900,7 @@ jobs:
 
   Init_RA_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -914,7 +914,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true
@@ -954,7 +954,7 @@ jobs:
 
   MySQL_test:
     timeout-minutes: 180
-    if: github.event_name == 'push' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
+    if: github.event_name == 'push' || github.event_name == 'schedule' || ${{ contains(github.event.pull_request.labels.*.name, 'SGX-hardware-test-required') }}
     runs-on: ${{ matrix.self_runner }}
     strategy:
       matrix:
@@ -968,7 +968,7 @@ jobs:
     - uses: AutoModality/action-clean@v1
 
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/checkout@v2
       with:
         submodules: true


### PR DESCRIPTION
1. Enable benchmark ci on schedule(Wed,Sat at 10PM UTC (6AM CST)) only on branch 1.0.0-preview
2. Improve hw ci: a. run on schedule(Tue,Fri at 6PM UTC (2AM CST)) b. lower stress test times under given limit(360 min)