### PR TITLE
Fix reserved memory permission for EDMM support

### DIFF
--- a/src/libos/src/vm/user_space_vm.rs
+++ b/src/libos/src/vm/user_space_vm.rs
@@ -24,11 +24,9 @@ impl UserSpaceVMManager {
             if ptr.is_null() {
                 return_errno!(ENOMEM, "run out of reserved memory");
             }
-            // Change the page permission to RW (default)
-            assert!(
-                sgx_tprotect_rsrv_mem(ptr, rsrv_mem_size, RSRV_MEM_PERM.bits())
-                    == sgx_status_t::SGX_SUCCESS
-            );
+
+            // Without EDMM support and the ReservedMemExecutable is set to 1, the reserved memory will be RWX. And we can't change the reserved memory permission.
+            // With EDMM support, the reserved memory permission is RW by default. And we can change the permissions when needed.
 
             let addr = ptr as usize;
             debug!(
@@ -100,15 +98,4 @@ extern "C" {
     // Return: 0 on success; otherwise -1
     //
     fn sgx_free_rsrv_mem(addr: *const c_void, length: usize) -> i32;
-
-    // Modify the access permissions of the pages in the reserved memory area
-    //
-    // Parameters:
-    // Inputs: addr[in]: Starting address of region which needs to change access
-    //         permission. Page aligned.
-    //         length[in]: The length of the memory to be manipulated in bytes. Page aligned.
-    //         prot[in]: The target memory protection.
-    // Return: sgx_status_t
-    //
-    fn sgx_tprotect_rsrv_mem(addr: *const c_void, length: usize, prot: i32) -> sgx_status_t;
 }

--- a/src/libos/src/vm/vm_perms.rs
+++ b/src/libos/src/vm/vm_perms.rs
@@ -33,14 +33,7 @@ impl VMPerms {
     }
 
     pub fn apply_perms(protect_range: &VMRange, perms: VMPerms) {
-        extern "C" {
-            pub fn occlum_ocall_mprotect(
-                retval: *mut i32,
-                addr: *const c_void,
-                len: usize,
-                prot: i32,
-            ) -> sgx_status_t;
-        };
+        use sgx_trts::enclave::rsgx_is_supported_EDMM;
 
         unsafe {
             let mut retval = 0;
@@ -50,8 +43,23 @@ impl VMPerms {
             // Since the memory are managed by our own, mprotect ocall shouldn't use this flag. Otherwise, EINVAL will be thrown.
             let mut prot = perms.clone();
             prot.remove(VMPerms::GROWSDOWN);
-            let sgx_status = occlum_ocall_mprotect(&mut retval, addr, len, prot.bits() as i32);
-            assert!(sgx_status == sgx_status_t::SGX_SUCCESS && retval == 0);
+
+            if rsgx_is_supported_EDMM() {
+                // With EDMM support, reserved memory permission should be updated.
+                // For sgx_tprotect_rsrv_mem, if the permission is only WRITE or EXEC, SGX_ERROR_INVALID_PARAMETER will return.
+                // Thus, we add READ here.
+                if !prot.can_read() && (prot.can_write() || prot.can_execute()) {
+                    prot.insert(VMPerms::READ);
+                }
+                assert!(
+                    sgx_tprotect_rsrv_mem(addr, len, prot.bits() as i32)
+                        == sgx_status_t::SGX_SUCCESS
+                );
+            } else {
+                // Without EDMM support, reserved memory permission is statically RWX and we only need to do mprotect ocall.
+                let sgx_status = occlum_ocall_mprotect(&mut retval, addr, len, prot.bits() as i32);
+                assert!(sgx_status == sgx_status_t::SGX_SUCCESS && retval == 0);
+            }
         }
     }
 
@@ -80,4 +88,24 @@ impl Default for VMPerms {
     fn default() -> Self {
         VMPerms::DEFAULT
     }
+}
+
+extern "C" {
+    // Modify the access permissions of the pages in the reserved memory area
+    //
+    // Parameters:
+    // Inputs: addr[in]: Starting address of region which needs to change access
+    //         permission. Page aligned.
+    //         length[in]: The length of the memory to be manipulated in bytes. Page aligned.
+    //         prot[in]: The target memory protection.
+    // Return: sgx_status_t
+    //
+    fn sgx_tprotect_rsrv_mem(addr: *const c_void, length: usize, prot: i32) -> sgx_status_t;
+
+    fn occlum_ocall_mprotect(
+        retval: *mut i32,
+        addr: *const c_void,
+        len: usize,
+        prot: i32,
+    ) -> sgx_status_t;
 }


### PR DESCRIPTION
Tested with SDK 2.18 and EDMM-enabled platform.