### PR TITLE
[glibc] No need build libcrypt from glibc

### DIFF
--- a/tools/toolchains/glibc/build.sh
+++ b/tools/toolchains/glibc/build.sh
@@ -28,6 +28,7 @@ cd ${BUILD_DIR}
 unset LD_LIBRARY_PATH
 CFLAGS="-O2 -g ${EXTRA_CFLAGS}" ${SRC_DIR}/configure \
   --prefix=${INSTALL_DIR} --with-tls --without-selinux \
-  --enable-stack-protector=strong --disable-nscd ${EXTRA_CONFIG_OPTION}
+  --enable-stack-protector=strong --disable-nscd --disable-crypt \
+  ${EXTRA_CONFIG_OPTION}
 make
 make install


### PR DESCRIPTION
The libcrypt.so built from glibc doesn't have "XCRYPT_2.0" section.
Using crypt implementation coming from libxcrypt which is installed already in Ubuntu 20.04.