### PR TITLE
[sefs] Make cache size configurable in Occlum.yaml

### DIFF
--- a/etc/template/Occlum.yaml
+++ b/etc/template/Occlum.yaml
@@ -110,6 +110,9 @@ mount:
           # to 1 to enforcing the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
           # So the data can only be accessed by the enclave itself.
           #  autokey_policy: 1
+          # The SEFS internal cache size, increasing it will bring better file I/O 
+          # performance but also consume Occlum's kernel heap size.
+          #  sefs_cache_size: 192KB
   #
   # HostFS mount
   # It provides a channel to exchange files between Host FS and LibOS FS.
@@ -129,7 +132,7 @@ mount:
   #   source: ./run/async_sfs_image
   #   options:
   #     # Total size that Async-SFS can manage. Must be specified.
-  #     total_size: 4GB
+  #     async_sfs_total_size: 4GB
   #     # Page cache size that Async-SFS can use. Must be specified.
   #     # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
   #     page_cache_size: 256MB

--- a/src/libos/src/config.rs
+++ b/src/libos/src/config.rs
@@ -194,10 +194,11 @@ pub struct ConfigMountOptions {
     pub mac: Option<sgx_aes_gcm_128bit_tag_t>,
     pub layers: Option<Vec<ConfigMount>>,
     pub temporary: bool,
-    pub total_size: Option<usize>,
+    pub async_sfs_total_size: Option<usize>,
     pub page_cache_size: Option<usize>,
     pub index: u32,
     pub autokey_policy: Option<u32>,
+    pub sefs_cache_size: Option<u64>,
 }
 
 impl Config {
@@ -349,16 +350,6 @@ impl ConfigMountOptions {
         } else {
             None
         };
-        let total_size = if input.total_size.is_some() {
-            Some(parse_memory_size(input.total_size.as_ref().unwrap())?)
-        } else {
-            None
-        };
-        let page_cache_size = if input.page_cache_size.is_some() {
-            Some(parse_memory_size(input.page_cache_size.as_ref().unwrap())?)
-        } else {
-            None
-        };
         let layers = if let Some(layers) = &input.layers {
             let layers = layers
                 .iter()
@@ -368,14 +359,32 @@ impl ConfigMountOptions {
         } else {
             None
         };
+        let async_sfs_total_size = if input.async_sfs_total_size.is_some() {
+            Some(parse_memory_size(
+                input.async_sfs_total_size.as_ref().unwrap(),
+            )?)
+        } else {
+            None
+        };
+        let page_cache_size = if input.page_cache_size.is_some() {
+            Some(parse_memory_size(input.page_cache_size.as_ref().unwrap())?)
+        } else {
+            None
+        };
+        let sefs_cache_size = if input.sefs_cache_size.is_some() {
+            Some(parse_memory_size(input.sefs_cache_size.as_ref().unwrap())? as _)
+        } else {
+            None
+        };
         Ok(ConfigMountOptions {
             mac,
             layers,
             temporary: input.temporary,
-            total_size,
+            async_sfs_total_size,
             page_cache_size,
             index: input.index,
             autokey_policy: input.autokey_policy,
+            sefs_cache_size,
         })
     }
 }
@@ -518,13 +527,15 @@ struct InputConfigMountOptions {
     #[serde(default)]
     pub temporary: bool,
     #[serde(default)]
-    pub total_size: Option<String>,
+    pub async_sfs_total_size: Option<String>,
     #[serde(default)]
     pub page_cache_size: Option<String>,
     #[serde(default)]
     pub index: u32,
     #[serde(default)]
     pub autokey_policy: Option<u32>,
+    #[serde(default)]
+    pub sefs_cache_size: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/libos/src/fs/sefs/mod.rs
+++ b/src/libos/src/fs/sefs/mod.rs
@@ -5,7 +5,3 @@ pub use self::sgx_uuid_provider::SgxUuidProvider;
 
 mod sgx_storage;
 mod sgx_uuid_provider;
-
-// Cache size of underlying SGX-PFS of SEFS
-// Default cache size: 0x1000 * 48
-const SEFS_CACHE_SIZE: u64 = 0x1000 * 256;

--- a/src/libos/src/fs/sefs/sgx_storage.rs
+++ b/src/libos/src/fs/sefs/sgx_storage.rs
@@ -32,6 +32,7 @@ pub struct SgxStorage {
     path: PathBuf,
     encrypt_mode: EncryptMode,
     file_cache: Mutex<BTreeMap<u64, LockedFile>>,
+    cache_size: Option<u64>,
 }
 
 impl SgxStorage {
@@ -40,13 +41,16 @@ impl SgxStorage {
         key: &Option<sgx_key_128bit_t>,
         root_mac: &Option<sgx_aes_gcm_128bit_tag_t>,
         autokey_policy: &Option<u32>,
-    ) -> Self {
+        cache_size: Option<u64>,
+    ) -> Result<Self> {
         // assert!(path.as_ref().is_dir());
-        SgxStorage {
+        Self::check_cache_size(&cache_size)?;
+        Ok(SgxStorage {
             path: path.as_ref().to_path_buf(),
             encrypt_mode: EncryptMode::new(key, root_mac, autokey_policy),
             file_cache: Mutex::new(BTreeMap::new()),
-        }
+            cache_size,
+        })
     }
     /// Get file by `file_id`.
     /// It lookups cache first, if miss, then call `open_fn` to open one,
@@ -85,6 +89,21 @@ impl SgxStorage {
     ) -> Result<LockedFile> {
         open_fn(self)
     }
+
+    fn check_cache_size(cache_size: &Option<u64>) -> Result<()> {
+        const PAGE_SIZE: u64 = 0x1000;
+        const DEFAULT_CACHE_SIZE: u64 = 48 * PAGE_SIZE;
+        if let Some(size) = *cache_size {
+            if size < DEFAULT_CACHE_SIZE || size % PAGE_SIZE != 0 {
+                error!(
+                    "invalid cache size: {}, must larger than default size: {} and aligned with page size: {}",
+                    size, DEFAULT_CACHE_SIZE, PAGE_SIZE
+                );
+                return_errno!(EINVAL, "invalid cache size");
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Storage for SgxStorage {
@@ -100,12 +119,12 @@ impl Storage for SgxStorage {
             let file = match self.encrypt_mode {
                 EncryptMode::IntegrityOnly(_) => options.open_integrity_only(path)?,
                 EncryptMode::EncryptWithIntegrity(key, _) | EncryptMode::Encrypt(key) => {
-                    options.open_with(path, Some(&key), None, Some(SEFS_CACHE_SIZE))?
+                    options.open_with(path, Some(&key), None, self.cache_size)?
                 }
                 EncryptMode::EncryptAutoKey(key_policy) => match key_policy {
-                    None => options.open(path)?,
+                    None => options.open_with(path, None, None, self.cache_size)?,
                     Some(policy) => {
-                        options.open_with(path, None, Some(policy.bits()), Some(SEFS_CACHE_SIZE))?
+                        options.open_with(path, None, Some(policy.bits()), self.cache_size)?
                     }
                 },
             };
@@ -140,12 +159,12 @@ impl Storage for SgxStorage {
             let file = match self.encrypt_mode {
                 EncryptMode::IntegrityOnly(_) => options.open_integrity_only(path)?,
                 EncryptMode::EncryptWithIntegrity(key, _) | EncryptMode::Encrypt(key) => {
-                    options.open_with(path, Some(&key), None, Some(SEFS_CACHE_SIZE))?
+                    options.open_with(path, Some(&key), None, self.cache_size)?
                 }
                 EncryptMode::EncryptAutoKey(key_policy) => match key_policy {
-                    None => options.open(path)?,
+                    None => options.open_with(path, None, None, self.cache_size)?,
                     Some(policy) => {
-                        options.open_with(path, None, Some(policy.bits()), Some(SEFS_CACHE_SIZE))?
+                        options.open_with(path, None, Some(policy.bits()), self.cache_size)?
                     }
                 },
             };

--- a/test/Occlum.yaml
+++ b/test/Occlum.yaml
@@ -126,5 +126,5 @@ mount:
     type: async_sfs
     source: ./run/async_sfs_image
     options:
-      total_size: 4GB
+      async_sfs_total_size: 4GB
       page_cache_size: 256MB

--- a/tools/gen_internal_conf/src/main.rs
+++ b/tools/gen_internal_conf/src/main.rs
@@ -159,7 +159,8 @@ fn main() {
         debug!("Occlum image is encrypted: {}", image_encrypted);
 
         // get the TCS number
-        let tcs_num = occlum_config.resource_limits.num_of_cpus + DEFAULT_CONFIG.num_of_tcs_used_by_occlum_kernel;
+        let tcs_num = occlum_config.resource_limits.num_of_cpus
+            + DEFAULT_CONFIG.num_of_tcs_used_by_occlum_kernel;
         let tcs_min_pool = tcs_num;
         let tcs_max_num = std::cmp::max(DEFAULT_CONFIG.num_of_cpus_max, tcs_num);
 
@@ -557,11 +558,13 @@ struct OcclumMountOptions {
     #[serde(default, skip_serializing_if = "is_false")]
     pub temporary: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_size: Option<String>,
+    pub async_sfs_total_size: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_cache_size: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     autokey_policy: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sefs_cache_size: Option<String>,
 }
 
 #[inline]


### PR DESCRIPTION
Similar modification in https://github.com/occlum/occlum/pull/1142
This PR
1. add `sefs_cache_size` to `ConfigMount.options`
2. rename `total_size` to `async_sfs_total_size` to avoid ambiguity