### PR TITLE
[async-rt] Simplify poll for TimerFutureEntry

### DIFF
--- a/src/libos/crates/async-rt/src/time/entry.rs
+++ b/src/libos/crates/async-rt/src/time/entry.rs
@@ -25,7 +25,8 @@ pub struct StartedInner {
 impl StartedInner {
     pub fn new(start_ticks: u64, waker: Waker) -> Self {
         Self {
-            start_ticks,
+            // This will be updated when the timer entry is inserted to the timer wheel.
+            start_ticks: start_ticks,
             waker: Some(waker),
         }
     }
@@ -83,8 +84,9 @@ impl TimerShared {
             TimerState::Init => {
                 self.state = TimerState::Cancelled(DURATION_ZERO);
             }
-            TimerState::Started(inner) => {
-                self.state = TimerState::Cancelled(inner.elapsed_time());
+            TimerState::Started(_) => {
+                // Timer wheel may not be updated, the elapsed time could overflow. Just return zero.
+                self.state = TimerState::Cancelled(DURATION_ZERO);
             }
             TimerState::Expired => {}
             TimerState::Cancelled(_) => panic!("Can not cancel twice"),
@@ -151,11 +153,17 @@ impl Future for TimerFutureEntry {
                     return Poll::Ready(());
                 }
 
-                // Insert the timer entry to the timer wheel.
                 let entry = TimerWheelEntry(self.0.clone());
-                let start_ticks = TIMER_WHEEL.insert_entry(entry, shared.timeout);
-                // Transfer to started state, set start_tick and waker.
-                let inner = StartedInner::new(start_ticks, cx.waker().clone());
+
+                // Insert the timer entry to the timer wheel pending list.
+                // Previously, there is too much work in "insert_entry", including making process for the timer wheel and fire timeout timers,
+                // which makes the poll slow and can cause the wait_timeout to fail to respond to other events.
+                // Now the heavy work is offloaded to the timer thread. And the current poll thread only inserts the timer into the pending list.
+                // The timer will then be inserted into the timer wheel by the timer thread when the timer thread is woken.
+                let start_tick = TIMER_WHEEL.insert_entry(entry, shared.timeout);
+
+                // Transfer to started state, set waker. start_ticks will be updated when inserting to the timer wheel.
+                let inner = StartedInner::new(start_tick, cx.waker().clone());
                 shared.state = TimerState::Started(inner);
                 Poll::Pending
             }
@@ -185,5 +193,10 @@ impl TimerWheelEntry {
     pub fn fire(&self) {
         let mut shared = self.0.lock();
         shared.fire();
+    }
+
+    pub fn remained_duration(&self) -> Duration {
+        let shared = self.0.lock();
+        shared.remained_duration()
     }
 }

--- a/src/libos/crates/async-rt/src/time/wheel.rs
+++ b/src/libos/crates/async-rt/src/time/wheel.rs
@@ -30,32 +30,35 @@ lazy_static! {
 pub fn run_timer_wheel_thread() {
     TIMER_WHEEL.set_running();
     loop {
-        // Lock the status.
-        let mut status = TIMER_WHEEL.status().lock();
-        debug_assert!(*status == TimerWheelStatus::Running);
-        let result = TIMER_WHEEL.try_make_progress();
-        if let Some(entries) = result.expired_timers {
-            drop(status);
-            // Don't hold lock when firing timers.
-            TimerWheel::fire(entries);
-        } else if let Some(skip) = result.skip {
-            let timeout = Duration::from_millis(skip as u64);
-            *status = TimerWheelStatus::Asleep(timeout);
-            drop(status);
+        {
+            // Lock the status.
+            let mut status = TIMER_WHEEL.status().lock();
+            debug_assert!(*status == TimerWheelStatus::Running);
+            let result = TIMER_WHEEL.try_make_progress();
+            if let Some(entries) = result.expired_timers {
+                drop(status);
+                // Don't hold lock when firing timers.
+                TimerWheel::fire(entries);
+            } else if let Some(skip) = result.skip {
+                let timeout = Duration::from_millis(skip as u64);
+                *status = TimerWheelStatus::Asleep(timeout);
+                drop(status);
 
-            debug!("Timer Wheel: will sleep {:?}", timeout);
-            let ret = futex_wait_timeout(&TIMER_WHEEL_WAKER, &timeout, WAKER_MAGIC_NUM);
+                debug!("Timer Wheel: will sleep {:?}", timeout);
+                let ret = futex_wait_timeout(&TIMER_WHEEL_WAKER, &timeout, WAKER_MAGIC_NUM);
 
-            // If timedout, set running by itself. If woken up, the status has been set by waker thread.
-            if ret.is_err() {
-                debug!("Timer Wheel: timeout");
-                TIMER_WHEEL.set_running();
-            } else {
-                debug!("Timer Wheel: woken up");
+                // If timedout, set running by itself. If woken up, the status has been set by waker thread.
+                if ret.is_err() {
+                    debug!("Timer Wheel: timeout");
+                    TIMER_WHEEL.set_running();
+                } else {
+                    debug!("Timer Wheel: woken up");
+                }
             }
-
-            TIMER_WHEEL.make_progress();
         }
+
+        // The timer wheel will make progress during the insertion
+        TIMER_WHEEL.insert_pending_entries();
 
         if EXECUTOR.is_shutdown() {
             break;
@@ -107,6 +110,8 @@ pub struct TimerWheel {
     start: Instant,
     // status of the timerwheel.
     status: Mutex<TimerWheelStatus>,
+    // Pending entries before adding to the wheel
+    pending_entries: Mutex<Vec<TimerWheelEntry>>,
 }
 
 impl TimerWheel {
@@ -116,6 +121,7 @@ impl TimerWheel {
             ticks: AtomicU64::new(0),
             start: Instant::now(),
             status: Mutex::new(TimerWheelStatus::Idle),
+            pending_entries: Mutex::new(Vec::new()),
         }
     }
 
@@ -134,27 +140,45 @@ impl TimerWheel {
         *self.status.lock() = TimerWheelStatus::Asleep(sleep_time)
     }
 
-    /// Insert a new timer entry to the wheel and return the ticks when the entry is inserted.
+    /// Insert a new timer entry to the wheel pending list
     pub fn insert_entry(&self, entry: TimerWheelEntry, timeout: Duration) -> u64 {
-        let mut guard = self.wheel.lock();
+        let mut pending_entries = self.pending_entries.lock();
+        pending_entries.push(entry);
 
-        // Try to make progress to assure that the wheel is up to date.
-        let entries = self.make_progress_locked(&mut guard);
-
-        // The minimum resolution of QuadWheelWithOverflow is 1 ms.
-        // Based on experiments, the timer is very likely to expire about 1 ms earlier, which truly follows the minimum resolution.
-        // But this is a unacceptable behavior for many test suite, because elapsed time could be smaller than timeout time.
-        // Thus, we wait one more milli-second here. For timeout less than 1 ms, we try to wait more than 1 ms.
-        let timeout = timeout + Duration::MILLISECOND;
-        guard.insert_with_delay(entry, timeout).unwrap();
-        let insert_ticks = self.latest_ticks();
-
-        drop(guard);
-        Self::fire(entries);
-
+        let elapsed = self.start.elapsed().as_millis() as u64;
         wake_timer_wheel(&timeout);
+        debug!("insert timer entry, timeout = {:?}", timeout);
+        elapsed
+    }
 
-        insert_ticks
+    pub fn insert_pending_entries(&self) {
+        let mut pending_entries = self.pending_entries.lock();
+        while pending_entries.len() > 0 {
+            let pending_entry = pending_entries.pop().unwrap();
+            let timeout_entries = {
+                let mut guard = self.wheel.lock();
+                // Try to make progress to assure that the wheel is up to date.
+                let timeout_entries = self.make_progress_locked(&mut guard);
+                let remained_timeout = pending_entry.remained_duration();
+
+                // The minimum resolution of QuadWheelWithOverflow is 1 ms.
+                // Based on experiments, the timer is very likely to expire about 1 ms earlier, which truly follows the minimum resolution.
+                // But this is a unacceptable behavior for many test suite, because elapsed time could be smaller than timeout time.
+                // Thus, we wait one more milli-second here. For timeout less than 1 ms, we try to wait more than 1 ms.
+                if remained_timeout == Duration::ZERO {
+                    Self::fire(vec![pending_entry]);
+                } else if remained_timeout <= Duration::MILLISECOND {
+                    let timeout = Duration::MILLISECOND;
+                    let _ = guard.insert_with_delay(pending_entry, timeout);
+                } else {
+                    let timeout = remained_timeout + Duration::MILLISECOND;
+                    let _ = guard.insert_with_delay(pending_entry, timeout);
+                }
+                timeout_entries
+            };
+
+            Self::fire(timeout_entries);
+        }
     }
 
     /// Try to move the timerwheel forward and fire expired timers.


### PR DESCRIPTION
Previously, there is too much work in "insert_entry", including making process for the timer wheel and fire timeout timers, which makes the poll slow and can cause the wait_timeout to fail to respond to other events. Now the heavy work is offloaded to the timer thread. And the current poll thread only inserts the timer into the pending list. The timer will then be inserted into the timer wheel by the timer thread when the timer thread is woken.