### PR TITLE
[libos] Fix the align_up & align_down assertions in prelude

### DIFF
--- a/src/libos/crates/block-device/src/util/mod.rs
+++ b/src/libos/crates/block-device/src/util/mod.rs
@@ -11,11 +11,9 @@ pub fn unbox<T: Sized>(value: Box<T>) -> T {
 }
 
 pub(crate) const fn align_down(x: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
     (x / align) * align
 }
 
 pub(crate) const fn align_up(x: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
     ((x + align - 1) / align) * align
 }

--- a/src/libos/crates/jindisk/src/util/mod.rs
+++ b/src/libos/crates/jindisk/src/util/mod.rs
@@ -14,11 +14,9 @@ pub(crate) use range_query_ctx::RangeQueryCtx;
 pub type BitMap = bitvec::prelude::BitVec<u8, bitvec::prelude::Lsb0>;
 
 pub(crate) const fn align_down(x: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
     (x / align) * align
 }
 
 pub(crate) const fn align_up(x: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
     ((x + align - 1) / align) * align
 }

--- a/src/libos/crates/sgx-untrusted-alloc/src/untrusted_allocator/vm_util.rs
+++ b/src/libos/crates/sgx-untrusted-alloc/src/untrusted_allocator/vm_util.rs
@@ -1,9 +1,9 @@
 pub fn align_down(addr: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
+    debug_assert!(align.is_power_of_two());
     addr & !(align - 1)
 }
 
 pub fn align_up(addr: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
+    debug_assert!(align.is_power_of_two());
     align_down(addr + (align - 1), align)
 }

--- a/src/libos/src/prelude.rs
+++ b/src/libos/src/prelude.rs
@@ -35,12 +35,12 @@ macro_rules! current {
 }
 
 pub fn align_up(addr: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
+    debug_assert!(align.is_power_of_two());
     align_down(addr + (align - 1), align)
 }
 
 pub fn align_down(addr: usize, align: usize) -> usize {
-    debug_assert!(align >= 2 && align.is_power_of_two());
+    debug_assert!(align.is_power_of_two());
     addr & !(align - 1)
 }
 


### PR DESCRIPTION
The `is_power_of_two()` ensures the alignment is not zero.