### PR TITLE
[jindisk] Support threaded logging

### DIFF
--- a/src/libos/crates/jindisk/src/checkpoint/bitc.rs
+++ b/src/libos/crates/jindisk/src/checkpoint/bitc.rs
@@ -53,7 +53,7 @@ impl BITC {
         self.l0_bit.as_ref().map(|bit| bit.clone())
     }
 
-    pub fn remove_bit(&mut self, bit_id: &BitId, level: LsmLevel) {
+    pub fn remove_bit(&mut self, bit_id: BitId, level: LsmLevel) {
         match level {
             0 => {
                 if let Some(l0_bit) = &self.l0_bit {
@@ -229,7 +229,7 @@ mod tests {
         assert!(old_l0_bit.is_some());
 
         let searched_bit = bitc.find_bit_by_lba(Lba::new(15), level0);
-        assert!(*searched_bit.unwrap().id() == id);
+        assert!(searched_bit.unwrap().id() == id);
 
         let id = BitId::from_byte_offset(5 * INDEX_SEGMENT_SIZE);
         let old_l0_bit = bitc.insert_bit(
@@ -240,14 +240,14 @@ mod tests {
         assert!(old_l0_bit.is_none());
 
         let searched_bit = bitc.find_bit_by_lba(Lba::new(25), level1);
-        assert!(*searched_bit.unwrap().id() == id);
+        assert!(searched_bit.unwrap().id() == id);
 
         let searched_bit =
             bitc.find_bit_by_lba_range(&LbaRange::new(Lba::new(20)..Lba::new(25)), level1);
-        assert!(*searched_bit[0].id() == id);
+        assert!(searched_bit[0].id() == id);
 
         assert!(
-            *bitc.find_bit_by_lba_range(&LbaRange::new(Lba::new(15)..Lba::new(25)), level1)[0].id()
+            bitc.find_bit_by_lba_range(&LbaRange::new(Lba::new(15)..Lba::new(25)), level1)[0].id()
                 == id
         );
         assert!(bitc
@@ -273,7 +273,7 @@ mod tests {
         bitc.encode(&mut bytes).unwrap();
         let decoded_bitc = BITC::decode(&bytes).unwrap();
 
-        assert_eq!(*decoded_bitc.l0_bit().unwrap().id(), id);
+        assert_eq!(decoded_bitc.l0_bit().unwrap().id(), id);
         assert_eq!(format!("{:?}", bitc), format!("{:?}", decoded_bitc));
     }
 

--- a/src/libos/crates/jindisk/src/checkpoint/mod.rs
+++ b/src/libos/crates/jindisk/src/checkpoint/mod.rs
@@ -28,6 +28,7 @@ pub struct Checkpoint {
     disk: DiskView,
 }
 // TODO: Introduce shadow paging for recovery
+// TODO: Support on-demand loading for every structure
 
 impl Checkpoint {
     pub fn new(superblock: &SuperBlock, disk: DiskView) -> Self {

--- a/src/libos/crates/jindisk/src/config.rs
+++ b/src/libos/crates/jindisk/src/config.rs
@@ -49,7 +49,7 @@ pub const SEGMENT_BUFFER_CAPACITY: usize = NUM_BLOCKS_PER_SEGMENT;
 pub const BUFFER_POOL_CAPACITY: usize = 16;
 
 /// # Garbage collection
-pub const GC_WATERMARK: usize = 8;
+pub const GC_WATERMARK: usize = 16;
 pub const GC_BACKGROUND_PERIOD: Duration = Duration::from_secs(5);
 
 /// # Index

--- a/src/libos/crates/jindisk/src/data/mod.rs
+++ b/src/libos/crates/jindisk/src/data/mod.rs
@@ -1,5 +1,4 @@
 //! Data region.
-// TODO: Support threaded logging
 mod cache;
 mod cleaning;
 mod state;

--- a/src/libos/crates/jindisk/src/index/bit/builder.rs
+++ b/src/libos/crates/jindisk/src/index/bit/builder.rs
@@ -230,9 +230,9 @@ mod tests {
                 .build(&records, &disk, level, version)
                 .await?;
 
-            assert_eq!(*bit.id(), BitId::new(1));
-            assert_eq!(*bit.level(), level);
-            assert_eq!(*bit.version(), version);
+            assert_eq!(bit.id(), BitId::new(1));
+            assert_eq!(bit.level(), level);
+            assert_eq!(bit.version(), version);
             Ok(())
         })
     }

--- a/src/libos/crates/jindisk/src/index/bit/disk_bit.rs
+++ b/src/libos/crates/jindisk/src/index/bit/disk_bit.rs
@@ -130,20 +130,20 @@ impl DiskBit {
         }
     }
 
-    pub fn id(&self) -> &BitId {
-        &self.id
+    pub fn id(&self) -> BitId {
+        self.id
     }
 
     pub fn lba_range(&self) -> &LbaRange {
         self.root_record.lba_range()
     }
 
-    pub fn version(&self) -> &BitVersion {
-        &self.version
+    pub fn version(&self) -> BitVersion {
+        self.version
     }
 
-    pub fn level(&self) -> &LsmLevel {
-        &self.level
+    pub fn level(&self) -> LsmLevel {
+        self.level
     }
 
     pub fn root_record(&self) -> &RootRecord {

--- a/src/libos/crates/jindisk/src/index/bit/mem_bit.rs
+++ b/src/libos/crates/jindisk/src/index/bit/mem_bit.rs
@@ -27,11 +27,11 @@ impl Bit {
         self.bit.lba_range()
     }
 
-    pub fn id(&self) -> &BitId {
+    pub fn id(&self) -> BitId {
         self.bit.id()
     }
 
-    pub fn version(&self) -> &BitVersion {
+    pub fn version(&self) -> BitVersion {
         self.bit.version()
     }
 
@@ -39,14 +39,13 @@ impl Bit {
         &self.bit.key()
     }
 
-    #[allow(unused)]
-    pub fn addr(&self) -> Hba {
-        *self.id() as _
+    pub fn level(&self) -> LsmLevel {
+        self.bit.level()
     }
 
     #[allow(unused)]
-    pub fn level(&self) -> &LsmLevel {
-        &self.bit.level()
+    pub fn addr(&self) -> Hba {
+        self.id() as _
     }
 
     #[allow(unused)]
@@ -375,8 +374,8 @@ impl Bit {
 impl Debug for Bit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BIT (Block Index Table)")
-            .field("id", self.id())
-            .field("version", self.version())
+            .field("id", &self.id())
+            .field("version", &self.version())
             .field("lba_range", self.lba_range())
             .finish()
     }

--- a/src/libos/crates/jindisk/src/index/reclaim.rs
+++ b/src/libos/crates/jindisk/src/index/reclaim.rs
@@ -69,7 +69,7 @@ pub fn apply_memtable_reclaim_policy<'a>(
     Box::pin(inner(checkpoint, coming_record, existed_record).into_future())
 }
 
-// TODO: Add reclamation policy in compaction
+// TODO: Add reclamation policy for compaction
 #[allow(unused)]
 async fn apply_compaction_reclaim_policy(
     checkpoint: &Arc<Checkpoint>,

--- a/src/libos/crates/jindisk/src/prelude.rs
+++ b/src/libos/crates/jindisk/src/prelude.rs
@@ -18,5 +18,5 @@ pub use crate::config::*;
 pub use crate::util::cryption::*;
 pub use crate::util::serialize::*;
 pub(crate) use crate::util::{align_down, align_up};
-pub(crate) use crate::util::{BitMap, DiskArray, DiskView, HbaRange, LbaRange};
+pub(crate) use crate::util::{BitMap, DiskArray, DiskRangeIter, DiskView, HbaRange, LbaRange};
 pub use crate::{Hba, JinDisk, Lba};

--- a/src/libos/crates/jindisk/src/util/disk_range.rs
+++ b/src/libos/crates/jindisk/src/util/disk_range.rs
@@ -46,23 +46,22 @@ impl LbaRange {
     }
 }
 
-/// Iterator for lba range.
-pub struct LbaRangeIter {
+/// Iterator for disk range.
+pub struct DiskRangeIter {
     pub start: Lba,
     pub end: Lba,
 }
 
-impl LbaRangeIter {
-    #[allow(unused)]
-    pub fn new(lba_range: &LbaRange) -> Self {
+impl DiskRangeIter {
+    pub fn new(disk_range: &LbaRange) -> Self {
         Self {
-            start: lba_range.start(),
-            end: lba_range.end(),
+            start: disk_range.start(),
+            end: disk_range.end(),
         }
     }
 }
 
-impl Iterator for LbaRangeIter {
+impl Iterator for DiskRangeIter {
     type Item = Lba;
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
@@ -97,7 +96,7 @@ mod tests {
         assert_eq!(lba_range.is_overlapped(&rhs_lba_range), true);
 
         let mut offset = lba_range.start();
-        let lba_range_iter = LbaRangeIter::new(&lba_range);
+        let lba_range_iter = DiskRangeIter::new(&lba_range);
         for lba in lba_range_iter {
             assert_eq!(lba, offset);
             offset = offset + 1 as _;

--- a/src/libos/crates/jindisk/src/util/mod.rs
+++ b/src/libos/crates/jindisk/src/util/mod.rs
@@ -7,7 +7,7 @@ mod range_query_ctx;
 pub mod serialize;
 
 pub(crate) use disk_array::DiskArray;
-pub(crate) use disk_range::{HbaRange, LbaRange};
+pub(crate) use disk_range::{DiskRangeIter, HbaRange, LbaRange};
 pub(crate) use disk_view::DiskView;
 pub(crate) use range_query_ctx::RangeQueryCtx;
 


### PR DESCRIPTION
This PR adds a new feature: threaded logging to JinDisk.

Threaded-logging enables JinDisk to log data in seperate blocks rather big segment. It triggers when disk space is running out. It automatically disables when background GC freed some segments. Foreground GC is no longer needed thanks to threaded logging.