### PR TITLE
[async-sfs&page-cache] Support batch read of consecutive blocks

### DIFF
--- a/src/libos/crates/async-sfs/src/lib.rs
+++ b/src/libos/crates/async-sfs/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(feature = "sgx", no_std)]
+#![feature(new_uninit)]
+#![feature(slice_group_by)]
 
 #[cfg(feature = "sgx")]
 extern crate sgx_types;

--- a/src/libos/crates/jindisk/src/data/cleaning.rs
+++ b/src/libos/crates/jindisk/src/data/cleaning.rs
@@ -103,6 +103,7 @@ impl Inner {
 
     async fn exec_background_cleaning(&self) -> Result<()> {
         let guard = self.a_lock.lock().await;
+        self.banish_migrants();
 
         let mut block_cnt = 0usize;
         let mut seg_cnt = 0usize;
@@ -115,7 +116,6 @@ impl Inner {
             }
         }
 
-        self.banish_migrants();
         debug!(
             "\n[Background Cleaning] complete. GC migrated {} blocks, freed {} segments\n",
             block_cnt, seg_cnt

--- a/src/libos/crates/page-cache/src/lib.rs
+++ b/src/libos/crates/page-cache/src/lib.rs
@@ -47,6 +47,7 @@
 #![feature(get_mut_unchecked)]
 #![feature(in_band_lifetimes)]
 #![feature(map_first_last)]
+#![feature(new_uninit)]
 #![feature(slice_group_by)]
 
 #[cfg(feature = "sgx")]

--- a/src/libos/crates/page-cache/src/prelude.rs
+++ b/src/libos/crates/page-cache/src/prelude.rs
@@ -2,7 +2,7 @@ pub(crate) use async_io::event::{Events, Pollee, Poller};
 pub(crate) use async_rt::sync::RwLock as AsyncRwLock;
 pub(crate) use async_rt::wait::{Waiter, WaiterQueue};
 pub(crate) use async_trait::async_trait;
-pub(crate) use errno::prelude::Result;
+pub(crate) use errno::prelude::{Result, *};
 pub(crate) use spin::mutex::{Mutex, MutexGuard};
 
 #[cfg(feature = "sgx")]

--- a/src/libos/crates/page-cache/tests/cached_disk_tests.rs
+++ b/src/libos/crates/page-cache/tests/cached_disk_tests.rs
@@ -24,21 +24,21 @@ macro_rules! new_cached_disk_for_tests {
 #[test]
 fn cached_disk_read_write() -> Result<()> {
     async_rt::task::block_on(async move {
-        let cached_disk = new_cached_disk_for_tests!(MB * 256);
+        let cached_disk = new_cached_disk_for_tests!(256 * MB);
         let content: u8 = 5;
-        const SIZE: usize = BLOCK_SIZE * 1;
-        const OFFSET: usize = 1024;
+        const RW_SIZE: usize = 2 * BLOCK_SIZE;
+        let offset = 1024;
 
-        let mut read_buf: [u8; SIZE] = [0; SIZE];
-        let len = cached_disk.read(OFFSET, &mut read_buf[..]).await?;
-        assert_eq!(SIZE, len, "[CachedDisk] read failed");
+        let mut read_buf: [u8; RW_SIZE] = [0; RW_SIZE];
+        let len = cached_disk.read(offset, &mut read_buf[..]).await?;
+        assert_eq!(RW_SIZE, len, "[CachedDisk] read failed");
 
-        let write_buf: [u8; SIZE] = [content; SIZE];
-        let len = cached_disk.write(OFFSET, &write_buf[..]).await?;
-        assert_eq!(SIZE, len, "[CachedDisk] write failed");
+        let write_buf: [u8; RW_SIZE] = [content; RW_SIZE];
+        let len = cached_disk.write(offset, &write_buf[..]).await?;
+        assert_eq!(RW_SIZE, len, "[CachedDisk] write failed");
 
-        let len = cached_disk.read(OFFSET, &mut read_buf[..]).await?;
-        assert_eq!(SIZE, len, "[CachedDisk] read failed");
+        let len = cached_disk.read(offset, &mut read_buf[..]).await?;
+        assert_eq!(RW_SIZE, len, "[CachedDisk] read failed");
         assert_eq!(read_buf, write_buf, "[CachedDisk] read wrong content");
 
         let rw_cnt = 10_0000;
@@ -57,7 +57,7 @@ fn cached_disk_read_write() -> Result<()> {
 #[test]
 fn cached_disk_flush() -> Result<()> {
     async_rt::task::block_on(async move {
-        let cached_disk = new_cached_disk_for_tests!(MB * 256);
+        let cached_disk = new_cached_disk_for_tests!(256 * MB);
         const SIZE: usize = BLOCK_SIZE;
         let write_cnt = 1;
         for i in 0..write_cnt {
@@ -87,7 +87,7 @@ fn cached_disk_flush() -> Result<()> {
 #[test]
 fn cached_disk_flush_pages() -> Result<()> {
     async_rt::task::block_on(async move {
-        let cached_disk = new_cached_disk_for_tests!(MB * 256);
+        let cached_disk = new_cached_disk_for_tests!(256 * MB);
         const SIZE: usize = BLOCK_SIZE;
         let write_cnt = 100;
         for i in 0..write_cnt {
@@ -109,7 +109,7 @@ fn cached_disk_flush_pages() -> Result<()> {
 #[test]
 fn cached_disk_flusher_task() -> Result<()> {
     async_rt::task::block_on(async move {
-        let cached_disk = Arc::new(new_cached_disk_for_tests!(MB * 256));
+        let cached_disk = Arc::new(new_cached_disk_for_tests!(256 * MB));
         let reader = cached_disk.clone();
         let writer = cached_disk.clone();
         const SIZE: usize = 4096;
@@ -147,7 +147,7 @@ fn cached_disk_flusher_task() -> Result<()> {
 #[test]
 fn cached_disk_evictor_task() -> Result<()> {
     async_rt::task::block_on(async move {
-        let cached_disk = new_cached_disk_for_tests!(BLOCK_SIZE * 100);
+        let cached_disk = new_cached_disk_for_tests!(100 * BLOCK_SIZE);
 
         // Support out-limit read/write thanks to the evictor task
         let rw_cnt = 500;


### PR DESCRIPTION
This PR optimizes read performance in AsyncSFS by enable batch read of consecutive blocks when a read request touches multi blocks.
A FIO benchmark comparison (seqwr-256k / randwr-32k / seqrd-256k / randrd-32k)
Before optimization:
![image](https://user-images.githubusercontent.com/22837133/230816612-6d85f051-d013-4467-b855-ccde4938a4cd.png)
After optimization:
![image](https://user-images.githubusercontent.com/22837133/230816655-da4f0570-e600-47b0-8af6-1583db6c5c54.png)
