### PR TITLE
[vm] Asynchronize vm subsystem to adapt AsyncSFS

### DIFF
--- a/src/libos/Cargo.lock
+++ b/src/libos/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "aligned",
  "async-io",
  "async-mountfs",
+ "async-recursion",
  "async-rt",
  "async-sfs",
  "async-socket",
@@ -121,6 +122,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+]
+
+[[package]]
 name = "async-rt"
 version = "0.1.0"
 dependencies = [
@@ -198,7 +210,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -323,7 +335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -357,7 +369,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.9.3",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -371,7 +383,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -382,7 +394,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -393,7 +405,7 @@ checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core 0.13.0",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -406,7 +418,7 @@ dependencies = [
  "derive_builder_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -418,7 +430,7 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -513,7 +525,7 @@ checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -577,7 +589,7 @@ dependencies = [
  "darling 0.13.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -754,7 +766,7 @@ checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -826,9 +838,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -845,9 +857,9 @@ source = "git+https://github.com/mesalock-linux/quick-error-sgx.git#468bf2cce746
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1107,7 +1119,7 @@ checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1130,7 +1142,7 @@ version = "1.0.104"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1351,6 +1363,17 @@ name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/libos/Cargo.toml
+++ b/src/libos/Cargo.toml
@@ -14,6 +14,7 @@ async-vfs = { path = "crates/async-vfs", features = ["sgx"] }
 async-sfs = { path = "crates/async-sfs", default-features = false, features = ["sgx"] }
 async-mountfs = { path = "crates/async-mountfs", features = ["sgx"] }
 async-trait = "0.1.52"
+async-recursion = "1.0.4"
 atomic = "0.5"
 bitflags = "1.0"
 bitvec = { version = "0.17", default-features = false, features = ["alloc"]  }

--- a/src/libos/crates/Cargo.lock
+++ b/src/libos/crates/Cargo.lock
@@ -161,6 +161,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-unionfs"
+version = "0.1.0"
+dependencies = [
+ "async-io",
+ "async-rt",
+ "async-sfs",
+ "async-trait",
+ "async-vfs",
+ "block-device",
+ "cfg-if",
+ "errno",
+ "libc",
+ "log",
+ "sgx_libc 1.1.5",
+ "sgx_trts 1.1.5",
+ "sgx_tstd 1.1.5",
+ "sgx_types 1.1.5",
+]
+
+[[package]]
 name = "async-vfs"
 version = "0.1.0"
 dependencies = [

--- a/src/libos/crates/async-rt/src/task/locals.rs
+++ b/src/libos/crates/async-rt/src/task/locals.rs
@@ -21,9 +21,9 @@ impl<T: Send + 'static> LocalKey<T> {
     /// Attempts to get a reference to the task-local value with this key.
     ///
     /// This method will panic if not called within the context of a task.
-    pub fn with<F, R>(&'static self, f: F) -> R
+    pub fn with<'a, F, R>(&'static self, f: F) -> R
     where
-        F: FnOnce(&T) -> R,
+        F: FnOnce(&'a T) -> R,
     {
         self.try_with(f).unwrap()
     }
@@ -32,9 +32,9 @@ impl<T: Send + 'static> LocalKey<T> {
     ///
     /// This method will not invoke the closure and return an `None` if not
     /// called within the context of a task.
-    pub fn try_with<F, R>(&'static self, f: F) -> Option<R>
+    pub fn try_with<'a, F, R>(&'static self, f: F) -> Option<R>
     where
-        F: FnOnce(&T) -> R,
+        F: FnOnce(&'a T) -> R,
     {
         let current = match crate::task::current::try_get() {
             Some(current) => current,

--- a/src/libos/src/entry/enclave.rs
+++ b/src/libos/src/entry/enclave.rs
@@ -278,9 +278,12 @@ pub extern "C" fn occlum_ecall_shutdown_vcpus() -> i32 {
 
     table::wait_all_process_exit();
 
-    // Flush the async rootfs
     async_rt::task::block_on(async {
+        // Flush the async rootfs
         crate::fs::rootfs().await.sync().await.unwrap();
+
+        // Free user space VM
+        crate::vm::free_user_space().await;
     });
 
     // TODO: stop all the kernel threads/tasks

--- a/src/libos/src/entry/exception/mod.rs
+++ b/src/libos/src/entry/exception/mod.rs
@@ -77,7 +77,7 @@ pub async fn handle_exception(exception: &Exception) -> Result<()> {
     // As the thread cannot proceed without handling the exception, we choose to force
     // delivering the signal regardless of the current signal mask.
     let signal = Box::new(FaultSignal::new(exception));
-    crate::signal::force_signal(signal);
+    crate::signal::force_signal(signal).await;
 
     Ok(())
 }

--- a/src/libos/src/entry/syscall.rs
+++ b/src/libos/src/entry/syscall.rs
@@ -662,12 +662,12 @@ async fn do_mmap(
 ) -> Result<isize> {
     let perms = VMPerms::from_u32(perms as u32)?;
     let flags = MMapFlags::from_u32(flags as u32)?;
-    let addr = vm::do_mmap(addr, size, perms, flags, fd, offset as usize)?;
+    let addr = vm::do_mmap(addr, size, perms, flags, fd, offset as usize).await?;
     Ok(addr as isize)
 }
 
 async fn do_munmap(addr: usize, size: usize) -> Result<isize> {
-    vm::do_munmap(addr, size)?;
+    vm::do_munmap(addr, size).await?;
     Ok(0)
 }
 
@@ -679,31 +679,31 @@ async fn do_mremap(
     new_addr: usize,
 ) -> Result<isize> {
     let flags = MRemapFlags::from_raw(flags as u32, new_addr)?;
-    let addr = vm::do_mremap(old_addr, old_size, new_size, flags)?;
+    let addr = vm::do_mremap(old_addr, old_size, new_size, flags).await?;
     Ok(addr as isize)
 }
 
 async fn do_mprotect(addr: usize, len: usize, perms: u32) -> Result<isize> {
     let perms = VMPerms::from_u32(perms as u32)?;
-    vm::do_mprotect(addr, len, perms)?;
+    vm::do_mprotect(addr, len, perms).await?;
     Ok(0)
 }
 
 async fn do_brk(new_brk_addr: usize) -> Result<isize> {
-    let ret_brk_addr = vm::do_brk(new_brk_addr)?;
+    let ret_brk_addr = vm::do_brk(new_brk_addr).await?;
     Ok(ret_brk_addr as isize)
 }
 
 async fn do_msync(addr: usize, size: usize, flags: u32) -> Result<isize> {
     let flags = MSyncFlags::from_u32(flags)?;
-    vm::do_msync(addr, size, flags)?;
+    vm::do_msync(addr, size, flags).await?;
     Ok(0)
 }
 
 async fn do_sysinfo(info: *mut sysinfo_t) -> Result<isize> {
     check_mut_ptr(info)?;
     let info = unsafe { &mut *info };
-    *info = crate::misc::do_sysinfo()?;
+    *info = crate::misc::do_sysinfo().await?;
     Ok(0)
 }
 

--- a/src/libos/src/entry/thread.rs
+++ b/src/libos/src/entry/thread.rs
@@ -31,7 +31,7 @@ async fn __main_loop(current: ThreadRef, init_cpu_state: CpuContext) {
     let mut rounds: u64 = 0;
 
     loop {
-        crate::signal::deliver_signal();
+        crate::signal::deliver_signal().await;
 
         crate::process::handle_force_stop().await;
 

--- a/src/libos/src/fs/file_ops/fsync.rs
+++ b/src/libos/src/fs/file_ops/fsync.rs
@@ -6,7 +6,7 @@ pub async fn do_fsync(fd: FileDesc) -> Result<()> {
     if let Some(disk_file) = file_ref.as_disk_file() {
         disk_file.flush().await?;
     } else if let Some(async_file_handle) = file_ref.as_async_file_handle() {
-        flush_vm_backed_by(&file_ref);
+        flush_vm_backed_by(&file_ref).await;
         async_file_handle.dentry().inode().sync_all().await?;
     } else {
         return_errno!(EBADF, "not supported");
@@ -20,7 +20,7 @@ pub async fn do_fdatasync(fd: FileDesc) -> Result<()> {
     if let Some(disk_file) = file_ref.as_disk_file() {
         disk_file.flush().await?;
     } else if let Some(async_file_handle) = file_ref.as_async_file_handle() {
-        flush_vm_backed_by(&file_ref);
+        flush_vm_backed_by(&file_ref).await;
         async_file_handle.dentry().inode().sync_data().await?;
     } else {
         return_errno!(EBADF, "not supported");
@@ -28,6 +28,6 @@ pub async fn do_fdatasync(fd: FileDesc) -> Result<()> {
     Ok(())
 }
 
-fn flush_vm_backed_by(file: &FileRef) {
-    current!().vm().msync_by_file(file);
+async fn flush_vm_backed_by(file: &FileRef) {
+    current!().vm().msync_by_file(file).await;
 }

--- a/src/libos/src/fs/procfs/meminfo.rs
+++ b/src/libos/src/fs/procfs/meminfo.rs
@@ -15,7 +15,7 @@ impl MemInfoINode {
 impl ProcINode for MemInfoINode {
     async fn generate_data_in_bytes(&self) -> Result<Vec<u8>> {
         let total_ram = USER_SPACE_VM_MANAGER.get_total_size();
-        let free_ram = current!().vm().get_free_size();
+        let free_ram = current!().vm().get_free_size().await;
         Ok(format!(
             "MemTotal:       {} kB\n\
              MemFree:        {} kB\n\

--- a/src/libos/src/ipc/syscalls.rs
+++ b/src/libos/src/ipc/syscalls.rs
@@ -7,7 +7,7 @@ use super::shm::{shmids_t, CmdId, ShmFlags, ShmId, SHM_MANAGER};
 pub async fn do_shmget(key: key_t, size: size_t, shmflg: i32) -> Result<isize> {
     let shmflg =
         ShmFlags::from_bits(shmflg as u32).ok_or_else(|| errno!(EINVAL, "invalid flags"))?;
-    let shmid = SHM_MANAGER.do_shmget(key, size, shmflg)?;
+    let shmid = SHM_MANAGER.do_shmget(key, size, shmflg).await?;
     Ok(shmid as isize)
 }
 
@@ -19,7 +19,7 @@ pub async fn do_shmat(shmid: i32, shmaddr: usize, shmflg: i32) -> Result<isize> 
 }
 
 pub async fn do_shmdt(shmaddr: usize) -> Result<isize> {
-    SHM_MANAGER.do_shmdt(shmaddr)?;
+    SHM_MANAGER.do_shmdt(shmaddr).await?;
     Ok(0)
 }
 
@@ -31,6 +31,8 @@ pub async fn do_shmctl(shmid: i32, cmd: i32, buf_u: *mut shmids_t) -> Result<isi
     } else {
         None
     };
-    SHM_MANAGER.do_shmctl(shmid as ShmId, cmd as CmdId, buf)?;
+    SHM_MANAGER
+        .do_shmctl(shmid as ShmId, cmd as CmdId, buf)
+        .await?;
     Ok(0)
 }

--- a/src/libos/src/lib.rs
+++ b/src/libos/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(concat_idents)]
 #![feature(trace_macros)]
+#![feature(extend_one)]
 // for !Send in rw_lock
 #![feature(negative_impls)]
 // for may_dangle in rw_lock

--- a/src/libos/src/misc/sysinfo.rs
+++ b/src/libos/src/misc/sysinfo.rs
@@ -22,11 +22,11 @@ pub struct sysinfo_t {
     mem_unit: u32,
 }
 
-pub fn do_sysinfo() -> Result<sysinfo_t> {
+pub async fn do_sysinfo() -> Result<sysinfo_t> {
     let info = sysinfo_t {
         uptime: time::up_time::get().unwrap().as_secs() as i64, // Duration can't be negative
         totalram: USER_SPACE_VM_MANAGER.get_total_size() as u64,
-        freeram: current!().vm().get_free_size() as u64,
+        freeram: current!().vm().get_free_size().await as u64,
         procs: table::get_all_processes().len() as u16,
         mem_unit: 1,
         ..Default::default()

--- a/src/libos/src/process/do_clone.rs
+++ b/src/libos/src/process/do_clone.rs
@@ -36,7 +36,9 @@ pub async fn do_clone(
         // Set the default user fsbase to an address on user stack, which is
         // a relatively safe address in case the user program uses %fs before
         // initializing fs base address.
-        guess_user_stack_bound(current!().vm(), user_rsp)?.start()
+        guess_user_stack_bound(current!().vm(), user_rsp)
+            .await?
+            .start()
     };
     let init_cpu_state = CpuContext {
         gp_regs: GpRegs {
@@ -248,9 +250,9 @@ fn check_clone_flags(flags: CloneFlags) -> Result<()> {
     Ok(())
 }
 
-fn guess_user_stack_bound(vm: &ProcessVM, user_rsp: usize) -> Result<VMRange> {
+async fn guess_user_stack_bound(vm: &ProcessVM, user_rsp: usize) -> Result<VMRange> {
     // The first case is most likely
-    if let Ok(stack_range) = vm.find_mmap_region(user_rsp) {
+    if let Ok(stack_range) = vm.find_mmap_region(user_rsp).await {
         Ok(stack_range)
     }
     // The next three cases are very unlikely, but valid

--- a/src/libos/src/process/do_exec.rs
+++ b/src/libos/src/process/do_exec.rs
@@ -76,7 +76,7 @@ pub async fn do_exec(
         wait_for_other_threads_to_exit(current_ref).await;
 
         // Exit current thread and let new process to adopt current's child process
-        exit_old_process_for_execve(term_status, new_process_ref.clone());
+        exit_old_process_for_execve(term_status, new_process_ref.clone()).await;
 
         // Update process and thread in global table
         table::replace_process(new_process_ref.pid(), new_process_ref.clone());

--- a/src/libos/src/process/do_spawn/init_vm.rs
+++ b/src/libos/src/process/do_spawn/init_vm.rs
@@ -5,7 +5,7 @@ use crate::misc::{resource_t, rlimit_t};
 use crate::prelude::*;
 use crate::vm::{ProcessVM, ProcessVMBuilder};
 
-pub fn do_init<'a, 'b>(
+pub async fn do_init<'a, 'b>(
     elf_file: &'b ElfFile<'a>,
     ldso_elf_file: &'b ElfFile<'a>,
 ) -> Result<ProcessVM> {
@@ -14,6 +14,7 @@ pub fn do_init<'a, 'b>(
         // process will directly use memory configuration in Occlum.json
         ProcessVMBuilder::new(vec![elf_file, ldso_elf_file])
             .build()
+            .await
             .cause_err(|e| errno!(e.errno(), "failed to create process VM"))?
     } else {
         // Parent process is not idle process. Inherit parent process's resource limit.
@@ -31,6 +32,7 @@ pub fn do_init<'a, 'b>(
             .set_stack_size(child_stack_size as usize)
             .clone()
             .build()
+            .await
             .cause_err(|e| errno!(e.errno(), "failed to create process VM"))?
     };
 

--- a/src/libos/src/vm/free_space_manager.rs
+++ b/src/libos/src/vm/free_space_manager.rs
@@ -2,10 +2,11 @@
 // Currently only use simple vector as the base structure.
 //
 // Basically use address-ordered first fit to find free ranges.
-use std::cmp::Ordering;
+use super::*;
 
 use super::vm_util::VMMapAddr;
-use super::*;
+
+use std::cmp::Ordering;
 
 const INITIAL_SIZE: usize = 100;
 

--- a/src/libos/src/vm/mod.rs
+++ b/src/libos/src/vm/mod.rs
@@ -77,13 +77,13 @@ use self::vm_layout::VMLayout;
 
 pub use self::chunk::{Chunk, ChunkRef, ChunkType};
 pub use self::process_vm::{MMapFlags, MRemapFlags, MSyncFlags, ProcessVM, ProcessVMBuilder};
-pub use self::user_space_vm::USER_SPACE_VM_MANAGER;
+pub use self::user_space_vm::{free_user_space, USER_SPACE_VM_MANAGER};
 pub use self::vm_area::VMArea;
 pub use self::vm_perms::VMPerms;
 pub use self::vm_range::VMRange;
 pub use self::vm_util::{VMInitializer, VMMapOptionsBuilder};
 
-pub fn do_mmap(
+pub async fn do_mmap(
     addr: usize,
     size: usize,
     perms: VMPerms,
@@ -103,16 +103,19 @@ pub fn do_mmap(
         );
     }
 
-    current!().vm().mmap(addr, size, perms, flags, fd, offset)
+    current!()
+        .vm()
+        .mmap(addr, size, perms, flags, fd, offset)
+        .await
 }
 
-pub fn do_munmap(addr: usize, size: usize) -> Result<()> {
+pub async fn do_munmap(addr: usize, size: usize) -> Result<()> {
     debug!("munmap: addr: {:#x}, size: {:#x}", addr, size);
     let current = current!();
-    current!().vm().munmap(addr, size)
+    current!().vm().munmap(addr, size).await
 }
 
-pub fn do_mremap(
+pub async fn do_mremap(
     old_addr: usize,
     old_size: usize,
     new_size: usize,
@@ -122,23 +125,26 @@ pub fn do_mremap(
         "mremap: old_addr: {:#x}, old_size: {:#x}, new_size: {:#x}, flags: {:?}",
         old_addr, old_size, new_size, flags
     );
-    current!().vm().mremap(old_addr, old_size, new_size, flags)
+    current!()
+        .vm()
+        .mremap(old_addr, old_size, new_size, flags)
+        .await
 }
 
-pub fn do_mprotect(addr: usize, size: usize, perms: VMPerms) -> Result<()> {
+pub async fn do_mprotect(addr: usize, size: usize, perms: VMPerms) -> Result<()> {
     debug!(
         "mprotect: addr: {:#x}, size: {:#x}, perms: {:?}",
         addr, size, perms
     );
-    current!().vm().mprotect(addr, size, perms)
+    current!().vm().mprotect(addr, size, perms).await
 }
 
-pub fn do_brk(addr: usize) -> Result<usize> {
+pub async fn do_brk(addr: usize) -> Result<usize> {
     debug!("brk: addr: {:#x}", addr);
-    current!().vm().brk(addr)
+    current!().vm().brk(addr).await
 }
 
-pub fn do_msync(addr: usize, size: usize, flags: MSyncFlags) -> Result<()> {
+pub async fn do_msync(addr: usize, size: usize, flags: MSyncFlags) -> Result<()> {
     debug!(
         "msync: addr: {:#x}, size: {:#x}, flags: {:?}",
         addr, size, flags
@@ -149,7 +155,7 @@ pub fn do_msync(addr: usize, size: usize, flags: MSyncFlags) -> Result<()> {
     if flags.contains(MSyncFlags::MS_ASYNC) {
         warn!("not support MS_ASYNC");
     }
-    current!().vm().msync(addr, size)
+    current!().vm().msync(addr, size).await
 }
 
 pub const PAGE_SIZE: usize = 4096;

--- a/src/libos/src/vm/process_vm.rs
+++ b/src/libos/src/vm/process_vm.rs
@@ -9,6 +9,8 @@ use super::vm_perms::VMPerms;
 use super::vm_util::{
     FileBacked, VMInitializer, VMMapAddr, VMMapOptions, VMMapOptionsBuilder, VMRemapOptions,
 };
+
+use async_rt::sync::{RwLock as AsyncRwLock, RwLockWriteGuard as AsyncRwLockWriteGuard};
 use std::collections::HashSet;
 use util::sync::RwLockWriteGuard;
 
@@ -38,7 +40,7 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
         self
     }
 
-    pub fn build(self) -> Result<ProcessVM> {
+    pub async fn build(self) -> Result<ProcessVM> {
         self.validate()?;
 
         let heap_size = self
@@ -87,10 +89,8 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
         let mut chunks = HashSet::new();
         // Init the memory for ELFs in the process
         let mut elf_ranges = Vec::with_capacity(2);
-        elf_layouts
-            .iter()
-            .zip(self.elfs.iter())
-            .map(|(elf_layout, elf_file)| {
+        for (elf_layout, elf_file) in elf_layouts.iter().zip(self.elfs.iter()) {
+            let vm_option = {
                 let vm_option = VMMapOptionsBuilder::default()
                     .size(elf_layout.size())
                     .align(elf_layout.align())
@@ -98,69 +98,80 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
                     .initializer(VMInitializer::ElfSpecific {
                         elf_file: elf_file.file_ref().clone(),
                     })
-                    .build()
-                    .map_err(|e| {
-                        &self.handle_error_when_init(&chunks);
-                        e
-                    })?;
-                let (elf_range, chunk_ref) =
-                    USER_SPACE_VM_MANAGER.alloc(&vm_option).map_err(|e| {
-                        &self.handle_error_when_init(&chunks);
-                        e
-                    })?;
-                debug_assert!(elf_range.start() % elf_layout.align() == 0);
-                chunks.insert(chunk_ref);
-                Self::init_elf_memory(&elf_range, elf_file).map_err(|e| {
-                    &self.handle_error_when_init(&chunks);
-                    e
-                })?;
-                trace!("elf range = {:?}", elf_range);
-                elf_ranges.push(elf_range);
-                Ok(())
-            })
-            .collect::<Result<()>>()?;
+                    .build();
+                if vm_option.is_err() {
+                    self.handle_error_when_init(&chunks).await;
+                }
+                vm_option?
+            };
+            let (elf_range, chunk_ref) = {
+                let res = USER_SPACE_VM_MANAGER.alloc(&vm_option).await;
+                if res.is_err() {
+                    self.handle_error_when_init(&chunks).await;
+                };
+                res?
+            };
+            debug_assert!(elf_range.start() % elf_layout.align() == 0);
+            chunks.insert(chunk_ref);
+            if let Err(e) = Self::init_elf_memory(&elf_range, elf_file).await {
+                self.handle_error_when_init(&chunks).await;
+                return Err(e);
+            }
+            trace!("elf range = {:?}", elf_range);
+            elf_ranges.push(elf_range);
+        }
 
         // Init the heap memory in the process
         let heap_layout = &other_layouts[0];
-        let vm_option = VMMapOptionsBuilder::default()
-            .size(heap_layout.size())
-            .align(heap_layout.align())
-            .perms(VMPerms::READ | VMPerms::WRITE)
-            .build()
-            .map_err(|e| {
-                &self.handle_error_when_init(&chunks);
-                e
-            })?;
+        let vm_option = {
+            let vm_option = VMMapOptionsBuilder::default()
+                .size(heap_layout.size())
+                .align(heap_layout.align())
+                .perms(VMPerms::READ | VMPerms::WRITE)
+                .build();
+            if vm_option.is_err() {
+                self.handle_error_when_init(&chunks).await
+            }
+            vm_option?
+        };
 
-        let (heap_range, chunk_ref) = USER_SPACE_VM_MANAGER.alloc(&vm_option).map_err(|e| {
-            &self.handle_error_when_init(&chunks);
-            e
-        })?;
+        let (heap_range, chunk_ref) = {
+            let res = USER_SPACE_VM_MANAGER.alloc(&vm_option).await;
+            if res.is_err() {
+                self.handle_error_when_init(&chunks).await
+            }
+            res?
+        };
         debug_assert!(heap_range.start() % heap_layout.align() == 0);
         trace!("heap range = {:?}", heap_range);
-        let brk = RwLock::new(heap_range.start());
+        let brk = AsyncRwLock::new(heap_range.start());
         chunks.insert(chunk_ref);
 
         // Init the stack memory in the process
         let stack_layout = &other_layouts[1];
-        let vm_option = VMMapOptionsBuilder::default()
-            .size(stack_layout.size())
-            .align(heap_layout.align())
-            .perms(VMPerms::READ | VMPerms::WRITE)
-            .build()
-            .map_err(|e| {
-                &self.handle_error_when_init(&chunks);
-                e
-            })?;
-        let (stack_range, chunk_ref) = USER_SPACE_VM_MANAGER.alloc(&vm_option).map_err(|e| {
-            &self.handle_error_when_init(&chunks);
-            e
-        })?;
+        let vm_option = {
+            let vm_option = VMMapOptionsBuilder::default()
+                .size(stack_layout.size())
+                .align(heap_layout.align())
+                .perms(VMPerms::READ | VMPerms::WRITE)
+                .build();
+            if vm_option.is_err() {
+                self.handle_error_when_init(&chunks).await
+            }
+            vm_option?
+        };
+        let (stack_range, chunk_ref) = {
+            let res = USER_SPACE_VM_MANAGER.alloc(&vm_option).await;
+            if res.is_err() {
+                self.handle_error_when_init(&chunks).await
+            }
+            res?
+        };
         debug_assert!(stack_range.start() % stack_layout.align() == 0);
         chunks.insert(chunk_ref);
         trace!("stack range = {:?}", stack_range);
 
-        let mem_chunks = Arc::new(RwLock::new(chunks));
+        let mem_chunks = Arc::new(AsyncRwLock::new(chunks));
         Ok(ProcessVM {
             elf_ranges,
             heap_range,
@@ -184,13 +195,17 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
         Ok(())
     }
 
-    fn handle_error_when_init(&self, chunks: &HashSet<Arc<Chunk>>) {
-        chunks.iter().for_each(|chunk| {
-            USER_SPACE_VM_MANAGER.internal().munmap_chunk(chunk, None);
-        });
+    async fn handle_error_when_init(&self, chunks: &HashSet<Arc<Chunk>>) {
+        for chunk in chunks.iter() {
+            USER_SPACE_VM_MANAGER
+                .internal()
+                .await
+                .munmap_chunk(chunk, None)
+                .await;
+        }
     }
 
-    fn init_elf_memory(elf_range: &VMRange, elf_file: &ElfFile) -> Result<()> {
+    async fn init_elf_memory(elf_range: &VMRange, elf_file: &ElfFile<'a>) -> Result<()> {
         // Destination buffer: ELF appeared in the process
         let elf_proc_buf = unsafe { elf_range.as_slice_mut() };
         // Source buffer: ELF stored in the ELF file
@@ -210,50 +225,48 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
         if !elf_file_handle.access_mode().readable() {
             return_errno!(EBADF, "elf file is not readable");
         }
-        let elf_file_inode = elf_file_handle
-            .dentry()
-            .inode()
-            .as_sync_inode()
-            .ok_or_else(|| errno!(EINVAL, "not sync inode"))?;
-        elf_file
+        let elf_file_inode = elf_file_handle.dentry().inode();
+        for segment in elf_file
             .program_headers()
             .filter(|segment| segment.loadable())
-            .for_each(|segment| {
-                let file_size = segment.p_filesz as usize;
-                let file_offset = segment.p_offset as usize;
-                let mem_addr = segment.p_vaddr as usize;
-                let mem_size = segment.p_memsz as usize;
-                let alignment = segment.p_align as usize;
-                debug_assert!(file_size <= mem_size);
+        {
+            let file_size = segment.p_filesz as usize;
+            let file_offset = segment.p_offset as usize;
+            let mem_addr = segment.p_vaddr as usize;
+            let mem_size = segment.p_memsz as usize;
+            let alignment = segment.p_align as usize;
+            debug_assert!(file_size <= mem_size);
 
-                let mem_start_offset = mem_addr - base_load_address_offset;
+            let mem_start_offset = mem_addr - base_load_address_offset;
 
-                // Initialize empty part to zero based on alignment
-                empty_start_offset = align_down(mem_start_offset, alignment);
-                for b in &mut elf_proc_buf[empty_start_offset..mem_start_offset] {
-                    *b = 0;
-                }
+            // Initialize empty part to zero based on alignment
+            empty_start_offset = align_down(mem_start_offset, alignment);
+            for b in &mut elf_proc_buf[empty_start_offset..mem_start_offset] {
+                *b = 0;
+            }
 
-                // Bytes of file_size length are loaded from the ELF file
-                elf_file_inode.read_at(
+            // Bytes of file_size length are loaded from the ELF file
+            elf_file_inode
+                .read_at(
                     file_offset,
                     &mut elf_proc_buf[mem_start_offset..mem_start_offset + file_size],
-                );
+                )
+                .await?;
 
-                // Set the remaining part to zero based on alignment
-                debug_assert!(file_size <= mem_size);
-                empty_end_offset = align_up(mem_start_offset + mem_size, alignment);
-                for b in &mut elf_proc_buf[mem_start_offset + file_size..empty_end_offset] {
-                    *b = 0;
-                }
-            });
+            // Set the remaining part to zero based on alignment
+            debug_assert!(file_size <= mem_size);
+            empty_end_offset = align_up(mem_start_offset + mem_size, alignment);
+            for b in &mut elf_proc_buf[mem_start_offset + file_size..empty_end_offset] {
+                *b = 0;
+            }
+        }
 
         Ok(())
     }
 }
 
 // MemChunks is the structure to track all the chunks which are used by this process.
-type MemChunks = Arc<RwLock<HashSet<ChunkRef>>>;
+type MemChunks = Arc<AsyncRwLock<HashSet<ChunkRef>>>;
 
 /// The per-process virtual memory
 #[derive(Debug)]
@@ -261,7 +274,7 @@ pub struct ProcessVM {
     elf_ranges: Vec<VMRange>,
     heap_range: VMRange,
     stack_range: VMRange,
-    brk: RwLock<usize>,
+    brk: AsyncRwLock<usize>,
     // Memory safety notes: the mem_chunks field must be the last one.
     //
     // Rust drops fields in the same order as they are declared. So by making
@@ -278,28 +291,13 @@ impl Default for ProcessVM {
             heap_range: Default::default(),
             stack_range: Default::default(),
             brk: Default::default(),
-            mem_chunks: Arc::new(RwLock::new(HashSet::new())),
+            mem_chunks: Arc::new(AsyncRwLock::new(HashSet::new())),
         }
     }
 }
 
 impl Drop for ProcessVM {
     fn drop(&mut self) {
-        let mut mem_chunks = self.mem_chunks.write().unwrap();
-        // There are two cases when this drop is called:
-        // (1) Process exits normally and in the end, drop process VM
-        // (2) During creating process stage, process VM is ready but there are some other errors when creating the process, e.g. spawn_attribute is set
-        // to a wrong value
-        //
-        // For the first case, the process VM is cleaned in the exit procedure and nothing is needed. For the second cases, mem_chunks is not empty and should
-        // be cleaned here.
-        mem_chunks
-            .drain_filter(|chunk| chunk.is_single_vma())
-            .for_each(|chunk| {
-                USER_SPACE_VM_MANAGER.internal().munmap_chunk(&chunk, None);
-            });
-
-        assert!(mem_chunks.len() == 0);
         info!("Process VM dropped");
     }
 }
@@ -317,25 +315,38 @@ impl ProcessVM {
         &self.heap_range
     }
 
-    pub fn add_mem_chunk(&self, chunk: ChunkRef) {
-        let mut mem_chunks = self.mem_chunks.write().unwrap();
+    pub async fn add_mem_chunk(&self, chunk: ChunkRef) {
+        let mut mem_chunks = self.mem_chunks.write().await;
         mem_chunks.insert(chunk);
     }
 
-    pub fn remove_mem_chunk(&self, chunk: &ChunkRef) {
-        let mut mem_chunks = self.mem_chunks.write().unwrap();
+    pub async fn remove_mem_chunk(&self, chunk: &ChunkRef) {
+        let mut mem_chunks = self.mem_chunks.write().await;
         mem_chunks.remove(chunk);
     }
 
-    pub fn replace_mem_chunk(&self, old_chunk: &ChunkRef, new_chunk: ChunkRef) {
-        self.remove_mem_chunk(old_chunk);
-        self.add_mem_chunk(new_chunk)
+    pub async fn replace_mem_chunk(&self, old_chunk: &ChunkRef, new_chunk: ChunkRef) {
+        self.remove_mem_chunk(old_chunk).await;
+        self.add_mem_chunk(new_chunk).await
+    }
+
+    // During creating process stage, process VM is ready but there are some other errors when creating the process,
+    // e.g. spawn_attribute is set to a wrong value
+    pub async fn free_mem_chunks_when_create_error(&self) {
+        let mut mem_chunks = self.mem_chunks.write().await;
+        for chunk in mem_chunks.drain_filter(|chunk| chunk.is_single_vma()) {
+            USER_SPACE_VM_MANAGER
+                .internal()
+                .await
+                .munmap_chunk(&chunk, None)
+                .await;
+        }
     }
 
     // Try merging all connecting single VMAs of the process.
     // This is a very expensive operation.
-    pub fn merge_all_single_vma_chunks(
-        mem_chunks: &mut RwLockWriteGuard<HashSet<ChunkRef>>,
+    pub async fn merge_all_single_vma_chunks(
+        mem_chunks: &mut AsyncRwLockWriteGuard<'_, HashSet<ChunkRef>>,
     ) -> Result<Vec<VMArea>> {
         // Get all single VMA chunks
         let mut single_vma_chunks = mem_chunks
@@ -357,14 +368,14 @@ impl ProcessVM {
                 ChunkType::MultiVMA(_) => {
                     unreachable!();
                 }
-                ChunkType::SingleVMA(vma) => vma.lock().unwrap(),
+                ChunkType::SingleVMA(vma) => vma.lock().await,
             };
 
             let mut vma_b = match chunk_b.internal() {
                 ChunkType::MultiVMA(_) => {
                     unreachable!();
                 }
-                ChunkType::SingleVMA(vma) => vma.lock().unwrap(),
+                ChunkType::SingleVMA(vma) => vma.lock().await,
             };
 
             if VMArea::can_merge_vmas(&vma_a, &vma_b) {
@@ -379,22 +390,17 @@ impl ProcessVM {
         let mut merged_vmas = Vec::new();
 
         // Insert unchanged chunks back to mem_chunks list and collect merged vmas for output
-        for chunk in single_vma_chunks.into_iter().filter_map(|chunk| {
-            if !chunk.is_single_dummy_vma() {
-                if chunk.is_single_vma_with_conflict_size() {
-                    let new_vma = chunk.get_vma_for_single_vma_chunk();
+        for chunk in single_vma_chunks.into_iter() {
+            if !chunk.is_single_dummy_vma().await {
+                if chunk.is_single_vma_with_conflict_size().await {
+                    let new_vma = chunk.get_vma_for_single_vma_chunk().await;
                     merged_vmas.push(new_vma);
 
                     // Don't insert the merged chunks to mem_chunk list here. It should be updated later.
-                    None
                 } else {
-                    Some(chunk)
+                    mem_chunks.insert(chunk);
                 }
-            } else {
-                None
             }
-        }) {
-            mem_chunks.insert(chunk);
         }
 
         Ok(merged_vmas)
@@ -428,16 +434,16 @@ impl ProcessVM {
         self.get_stack_range().start()
     }
 
-    pub fn get_brk(&self) -> usize {
-        *self.brk.read().unwrap()
+    pub async fn get_brk(&self) -> usize {
+        *self.brk.read().await
     }
 
-    pub fn brk(&self, brk: usize) -> Result<usize> {
+    pub async fn brk(&self, brk: usize) -> Result<usize> {
         let heap_start = self.heap_range.start();
         let heap_end = self.heap_range.end();
 
         // Acquire lock first to avoid data-race.
-        let mut brk_guard = self.brk.write().unwrap();
+        let mut brk_guard = self.brk.write().await;
 
         if brk >= heap_start && brk <= heap_end {
             // Get page-aligned brk address.
@@ -449,7 +455,7 @@ impl ProcessVM {
             if new_brk < old_brk {
                 let shrink_brk_range =
                     VMRange::new(new_brk, old_brk).expect("shrink brk range must be valid");
-                USER_SPACE_VM_MANAGER.reset_memory(shrink_brk_range)?;
+                USER_SPACE_VM_MANAGER.reset_memory(shrink_brk_range).await?;
             }
 
             // Return the user-specified brk address without page aligned. This is same as Linux.
@@ -467,18 +473,20 @@ impl ProcessVM {
     }
 
     // Get a NON-accurate free size for current process
-    pub fn get_free_size(&self) -> usize {
+    pub async fn get_free_size(&self) -> usize {
         let chunk_free_size = {
-            let process_chunks = self.mem_chunks.read().unwrap();
-            process_chunks
-                .iter()
-                .fold(0, |acc, chunks| acc + chunks.free_size())
+            let mut chunk_free_size = 0;
+            let process_chunks = self.mem_chunks.read().await;
+            for chunk in process_chunks.iter() {
+                chunk_free_size += chunk.free_size().await;
+            }
+            chunk_free_size
         };
-        let free_size = chunk_free_size + USER_SPACE_VM_MANAGER.free_size();
+        let free_size = chunk_free_size + USER_SPACE_VM_MANAGER.free_size().await;
         free_size
     }
 
-    pub fn mmap(
+    pub async fn mmap(
         &self,
         addr: usize,
         size: usize,
@@ -521,11 +529,11 @@ impl ProcessVM {
             .perms(perms)
             .initializer(initializer)
             .build()?;
-        let mmap_addr = USER_SPACE_VM_MANAGER.mmap(&mmap_options)?;
+        let mmap_addr = USER_SPACE_VM_MANAGER.mmap(&mmap_options).await?;
         Ok(mmap_addr)
     }
 
-    pub fn mremap(
+    pub async fn mremap(
         &self,
         old_addr: usize,
         old_size: usize,
@@ -533,14 +541,14 @@ impl ProcessVM {
         flags: MRemapFlags,
     ) -> Result<usize> {
         let mremap_option = VMRemapOptions::new(old_addr, old_size, new_size, flags)?;
-        USER_SPACE_VM_MANAGER.mremap(&mremap_option)
+        USER_SPACE_VM_MANAGER.mremap(&mremap_option).await
     }
 
-    pub fn munmap(&self, addr: usize, size: usize) -> Result<()> {
-        USER_SPACE_VM_MANAGER.munmap(addr, size)
+    pub async fn munmap(&self, addr: usize, size: usize) -> Result<()> {
+        USER_SPACE_VM_MANAGER.munmap(addr, size).await
     }
 
-    pub fn mprotect(&self, addr: usize, size: usize, perms: VMPerms) -> Result<()> {
+    pub async fn mprotect(&self, addr: usize, size: usize, perms: VMPerms) -> Result<()> {
         let size = {
             if size == 0 {
                 return Ok(());
@@ -549,20 +557,20 @@ impl ProcessVM {
         };
         let protect_range = VMRange::new_with_size(addr, size)?;
 
-        return USER_SPACE_VM_MANAGER.mprotect(addr, size, perms);
+        return USER_SPACE_VM_MANAGER.mprotect(addr, size, perms).await;
     }
 
-    pub fn msync(&self, addr: usize, size: usize) -> Result<()> {
-        return USER_SPACE_VM_MANAGER.msync(addr, size);
+    pub async fn msync(&self, addr: usize, size: usize) -> Result<()> {
+        return USER_SPACE_VM_MANAGER.msync(addr, size).await;
     }
 
-    pub fn msync_by_file(&self, sync_file: &FileRef) {
-        return USER_SPACE_VM_MANAGER.msync_by_file(sync_file);
+    pub async fn msync_by_file(&self, sync_file: &FileRef) {
+        return USER_SPACE_VM_MANAGER.msync_by_file(sync_file).await;
     }
 
     // Return: a copy of the found region
-    pub fn find_mmap_region(&self, addr: usize) -> Result<VMRange> {
-        USER_SPACE_VM_MANAGER.find_mmap_region(addr)
+    pub async fn find_mmap_region(&self, addr: usize) -> Result<VMRange> {
+        USER_SPACE_VM_MANAGER.find_mmap_region(addr).await
     }
 }
 

--- a/src/libos/src/vm/vm_manager.rs
+++ b/src/libos/src/vm/vm_manager.rs
@@ -9,10 +9,12 @@ use super::vm_chunk_manager::ChunkManager;
 use super::vm_perms::VMPerms;
 use super::vm_util::*;
 use crate::process::{ThreadRef, ThreadStatus};
-use std::ops::Bound::{Excluded, Included};
-
 use crate::util::sync::*;
+
+use async_recursion::async_recursion;
+use async_rt::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
 use std::collections::{BTreeSet, HashSet};
+use std::ops::Bound::{Excluded, Included};
 
 // When allocating chunks, each allocation will have a random offset above the start address of available space.
 // The random value will be in [0, CHUNK_RANDOM_OFFSET].
@@ -26,7 +28,7 @@ const CHUNK_RANDOM_RANGE: usize = 1024 * 1024; // 1M
 #[derive(Debug)]
 pub struct VMManager {
     range: VMRange,
-    internal: SgxMutex<InternalVMManager>,
+    internal: AsyncMutex<InternalVMManager>,
 }
 
 impl VMManager {
@@ -34,7 +36,7 @@ impl VMManager {
         let internal = InternalVMManager::init(vm_range.clone());
         Ok(VMManager {
             range: vm_range,
-            internal: SgxMutex::new(internal),
+            internal: AsyncMutex::new(internal),
         })
     }
 
@@ -42,33 +44,33 @@ impl VMManager {
         &self.range
     }
 
-    pub fn internal(&self) -> SgxMutexGuard<InternalVMManager> {
-        self.internal.lock().unwrap()
+    pub async fn internal(&self) -> AsyncMutexGuard<'_, InternalVMManager> {
+        self.internal.lock().await
     }
 
-    pub fn free_size(&self) -> usize {
-        self.internal().free_manager.free_size()
+    pub async fn free_size(&self) -> usize {
+        self.internal().await.free_manager.free_size()
     }
 
-    pub fn verified_clean_when_exit(&self) -> bool {
-        let internal = self.internal();
+    pub async fn verified_clean_when_exit(&self) -> bool {
+        let internal = self.internal().await;
         internal.chunks.len() == 0 && internal.free_manager.free_size() == self.range.size()
     }
 
-    pub fn free_chunk(&self, chunk: &ChunkRef) {
-        let mut internal = self.internal();
+    pub async fn free_chunk(&self, chunk: &ChunkRef) {
+        let mut internal = self.internal().await;
         internal.free_chunk(chunk);
     }
 
     // Allocate single VMA chunk for new process whose process VM is not ready yet
-    pub fn alloc(&self, options: &VMMapOptions) -> Result<(VMRange, ChunkRef)> {
-        if let Ok(new_chunk) = self.internal().mmap_chunk(options) {
+    pub async fn alloc(&self, options: &VMMapOptions) -> Result<(VMRange, ChunkRef)> {
+        if let Ok(new_chunk) = self.internal().await.mmap_chunk(options).await {
             return Ok((new_chunk.range().clone(), new_chunk));
         }
         return_errno!(ENOMEM, "can't allocate free chunks");
     }
 
-    pub fn mmap(&self, options: &VMMapOptions) -> Result<usize> {
+    pub async fn mmap(&self, options: &VMMapOptions) -> Result<usize> {
         let addr = *options.addr();
         let size = *options.size();
         let align = *options.align();
@@ -77,21 +79,29 @@ impl VMManager {
             VMMapAddr::Any => {}
             VMMapAddr::Hint(addr) => {
                 let target_range = VMRange::new_with_size(addr, size)?;
-                let ret = self.internal().mmap_with_addr(target_range, options);
+                let ret = self
+                    .internal()
+                    .await
+                    .mmap_with_addr(target_range, options)
+                    .await;
                 if ret.is_ok() {
                     return ret;
                 }
             }
             VMMapAddr::Need(addr) | VMMapAddr::Force(addr) => {
                 let target_range = VMRange::new_with_size(addr, size)?;
-                return self.internal().mmap_with_addr(target_range, options);
+                return self
+                    .internal()
+                    .await
+                    .mmap_with_addr(target_range, options)
+                    .await;
             }
         }
 
         if size > CHUNK_DEFAULT_SIZE {
-            if let Ok(new_chunk) = self.internal().mmap_chunk(options) {
+            if let Ok(new_chunk) = self.internal().await.mmap_chunk(options).await {
                 let start = new_chunk.range().start();
-                current!().vm().add_mem_chunk(new_chunk);
+                current!().vm().add_mem_chunk(new_chunk).await;
                 return Ok(start);
             } else {
                 return_errno!(ENOMEM, "can't allocate free chunks");
@@ -103,12 +113,12 @@ impl VMManager {
         {
             // Fast path: Try to go to assigned chunks to do mmap
             // There is no lock on VMManager in this path.
-            let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+            let process_mem_chunks = current.vm().mem_chunks().read().await;
             for chunk in process_mem_chunks
                 .iter()
                 .filter(|&chunk| !chunk.is_single_vma())
             {
-                let result_start = chunk.try_mmap(options);
+                let result_start = chunk.try_mmap(options).await;
                 if result_start.is_ok() {
                     return result_start;
                 }
@@ -118,39 +128,35 @@ impl VMManager {
         // Process' chunks are all busy or can't allocate from process_mem_chunks list.
         // Allocate a new chunk with chunk default size.
         // Lock on ChunkManager.
-        if let Ok(new_chunk) = self.internal().mmap_chunk_default(addr) {
+        if let Ok(new_chunk) = self.internal().await.mmap_chunk_default(addr) {
             // Add this new chunk to process' chunk list
             new_chunk.add_process(&current);
-            current.vm().add_mem_chunk(new_chunk.clone());
+            current.vm().add_mem_chunk(new_chunk.clone()).await;
 
             // Allocate in the new chunk
             // This mmap could still fail due to invalid options
-            return new_chunk.mmap(options);
+            return new_chunk.mmap(options).await;
         }
 
         // Slow path: Sadly, there is no free chunk, iterate every chunk to find a range
         {
             // Release lock after this block
             let mut result_start = Ok(0);
-            let chunks = &self.internal().chunks;
-            let chunk = chunks
-                .iter()
-                .filter(|&chunk| !chunk.is_single_vma())
-                .find(|&chunk| {
-                    result_start = chunk.mmap(options);
-                    result_start.is_ok()
-                });
-            if let Some(chunk) = chunk {
-                chunk.add_process(&current);
-                current.vm().add_mem_chunk(chunk.clone());
-                return result_start;
+            let chunks = &self.internal().await.chunks;
+            for chunk in chunks.iter().filter(|&chunk| !chunk.is_single_vma()) {
+                result_start = chunk.mmap(options).await;
+                if result_start.is_ok() {
+                    chunk.add_process(&current);
+                    current.vm().add_mem_chunk(chunk.clone()).await;
+                    return result_start;
+                }
             }
         }
 
         // Can't find a range in default chunks. Maybe there is still free range in the global free list.
-        if let Ok(new_chunk) = self.internal().mmap_chunk(options) {
+        if let Ok(new_chunk) = self.internal().await.mmap_chunk(options).await {
             let start = new_chunk.range().start();
-            current!().vm().add_mem_chunk(new_chunk);
+            current!().vm().add_mem_chunk(new_chunk).await;
             return Ok(start);
         }
 
@@ -158,7 +164,7 @@ impl VMManager {
         return_errno!(ENOMEM, "Can't find a free chunk for this allocation");
     }
 
-    pub fn munmap(&self, addr: usize, size: usize) -> Result<()> {
+    pub async fn munmap(&self, addr: usize, size: usize) -> Result<()> {
         // Go to every process chunk to see if it contains the range.
         let size = {
             if size == 0 {
@@ -169,7 +175,7 @@ impl VMManager {
         let munmap_range = { VMRange::new_with_size(addr, size) }?;
         let current = current!();
         let chunk = {
-            let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+            let process_mem_chunks = current.vm().mem_chunks().read().await;
             let chunk = process_mem_chunks
                 .iter()
                 .find(|&chunk| chunk.range().intersect(&munmap_range).is_some());
@@ -189,9 +195,9 @@ impl VMManager {
             // munmap range spans multiple chunks
 
             // Must lock the internal manager first here in case the chunk's range and vma are conflict when other threads are operating the VM
-            let mut internal_manager = self.internal();
+            let mut internal_manager = self.internal().await;
             let overlapping_chunks = {
-                let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+                let process_mem_chunks = current.vm().mem_chunks().read().await;
                 process_mem_chunks
                     .iter()
                     .filter(|p_chunk| p_chunk.range().overlap_with(&munmap_range))
@@ -202,13 +208,18 @@ impl VMManager {
             for chunk in overlapping_chunks.iter() {
                 match chunk.internal() {
                     ChunkType::SingleVMA(_) => {
-                        internal_manager.munmap_chunk(chunk, Some(&munmap_range))?
+                        internal_manager
+                            .munmap_chunk(chunk, Some(&munmap_range))
+                            .await?
                     }
-                    ChunkType::MultiVMA(manager) => manager
-                        .lock()
-                        .unwrap()
-                        .chunk_manager_mut()
-                        .munmap_range(munmap_range)?,
+                    ChunkType::MultiVMA(manager) => {
+                        manager
+                            .lock()
+                            .await
+                            .chunk_manager_mut()
+                            .munmap_range(munmap_range)
+                            .await?
+                    }
                 }
             }
             return Ok(());
@@ -220,23 +231,26 @@ impl VMManager {
             ChunkType::MultiVMA(manager) => {
                 return manager
                     .lock()
-                    .unwrap()
+                    .await
                     .chunk_manager_mut()
-                    .munmap_range(munmap_range);
+                    .munmap_range(munmap_range)
+                    .await;
             }
             ChunkType::SingleVMA(_) => {
                 // Single VMA Chunk could be updated during the release of internal manager lock. Get overlapping chunk again.
                 // This is done here because we don't want to acquire the big internal manager lock as soon as entering this function.
-                let mut internal_manager = self.internal();
+                let mut internal_manager = self.internal().await;
                 let overlapping_chunk = {
-                    let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+                    let process_mem_chunks = current.vm().mem_chunks().read().await;
                     process_mem_chunks
                         .iter()
                         .find(|&chunk| chunk.range().intersect(&munmap_range).is_some())
                         .map(|chunk| chunk.clone())
                 };
                 if let Some(overlapping_chunk) = overlapping_chunk {
-                    return internal_manager.munmap_chunk(&overlapping_chunk, Some(&munmap_range));
+                    return internal_manager
+                        .munmap_chunk(&overlapping_chunk, Some(&munmap_range))
+                        .await;
                 } else {
                     warn!("no overlapping chunks anymore");
                     return Ok(());
@@ -245,22 +259,24 @@ impl VMManager {
         }
     }
 
-    pub fn find_mmap_region(&self, addr: usize) -> Result<VMRange> {
+    pub async fn find_mmap_region(&self, addr: usize) -> Result<VMRange> {
         let current = current!();
-        let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+        let process_mem_chunks = current.vm().mem_chunks().read().await;
         let mut vm_range = Ok(Default::default());
-        process_mem_chunks.iter().find(|&chunk| {
-            vm_range = chunk.find_mmap_region(addr);
-            vm_range.is_ok()
-        });
+        for chunk in process_mem_chunks.iter() {
+            vm_range = chunk.find_mmap_region(addr).await;
+            if vm_range.is_ok() {
+                break;
+            }
+        }
         return vm_range;
     }
 
-    pub fn mprotect(&self, addr: usize, size: usize, perms: VMPerms) -> Result<()> {
+    pub async fn mprotect(&self, addr: usize, size: usize, perms: VMPerms) -> Result<()> {
         let protect_range = VMRange::new_with_size(addr, size)?;
         let chunk = {
             let current = current!();
-            let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+            let process_mem_chunks = current.vm().mem_chunks().read().await;
             let chunk = process_mem_chunks
                 .iter()
                 .find(|&chunk| chunk.range().intersect(&protect_range).is_some());
@@ -280,22 +296,25 @@ impl VMManager {
                 trace!("mprotect default chunk: {:?}", chunk.range());
                 return manager
                     .lock()
-                    .unwrap()
+                    .await
                     .chunk_manager_mut()
                     .mprotect(addr, size, perms);
             }
             ChunkType::SingleVMA(_) => {
-                let mut internal_manager = self.internal();
-                return internal_manager.mprotect_single_vma_chunk(&chunk, protect_range, perms);
+                let mut internal_manager = self.internal().await;
+                return internal_manager
+                    .mprotect_single_vma_chunk(&chunk, protect_range, perms)
+                    .await;
             }
         }
     }
 
     // Reset memory permission to default (R/W) and reset the memory contents to zero. Currently only used by brk.
-    pub fn reset_memory(&self, reset_range: VMRange) -> Result<()> {
+    pub async fn reset_memory(&self, reset_range: VMRange) -> Result<()> {
         let intersect_chunks = {
             let chunks = self
                 .internal()
+                .await
                 .chunks
                 .iter()
                 .filter(|&chunk| chunk.range().intersect(&reset_range).is_some())
@@ -303,24 +322,21 @@ impl VMManager {
                 .collect::<Vec<_>>();
 
             // In the heap area, there shouldn't be any default chunks or chunks owned by other process.
-            if chunks
-                .iter()
-                .any(|chunk| !chunk.is_owned_by_current_process() || !chunk.is_single_vma())
-            {
-                return_errno!(EINVAL, "There is something wrong with the intersect chunks");
+            for chunk in chunks.iter() {
+                if !chunk.is_owned_by_current_process().await || !chunk.is_single_vma() {
+                    return_errno!(EINVAL, "There is something wrong with the intersect chunks");
+                }
             }
             chunks
         };
 
-        intersect_chunks.iter().for_each(|chunk| {
+        for chunk in intersect_chunks.iter() {
             if let ChunkType::SingleVMA(vma) = chunk.internal() {
                 if let Some(intersection_range) = chunk.range().intersect(&reset_range) {
-                    let mut internal_manager = self.internal();
-                    internal_manager.mprotect_single_vma_chunk(
-                        &chunk,
-                        intersection_range,
-                        VMPerms::DEFAULT,
-                    );
+                    let mut internal_manager = self.internal().await;
+                    internal_manager
+                        .mprotect_single_vma_chunk(&chunk, intersection_range, VMPerms::DEFAULT)
+                        .await;
 
                     unsafe {
                         let buf = intersection_range.as_slice_mut();
@@ -328,16 +344,16 @@ impl VMManager {
                     }
                 }
             }
-        });
+        }
 
         Ok(())
     }
 
-    pub fn msync(&self, addr: usize, size: usize) -> Result<()> {
+    pub async fn msync(&self, addr: usize, size: usize) -> Result<()> {
         let sync_range = VMRange::new_with_size(addr, size)?;
         let chunk = {
             let current = current!();
-            let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+            let process_mem_chunks = current.vm().mem_chunks().read().await;
             let chunk = process_mem_chunks
                 .iter()
                 .find(|&chunk| chunk.range().is_superset_of(&sync_range));
@@ -352,39 +368,44 @@ impl VMManager {
                 trace!("msync default chunk: {:?}", chunk.range());
                 return manager
                     .lock()
-                    .unwrap()
+                    .await
                     .chunk_manager_mut()
-                    .msync_by_range(&sync_range);
+                    .msync_by_range(&sync_range)
+                    .await;
             }
             ChunkType::SingleVMA(vma) => {
-                let vma = vma.lock().unwrap();
-                ChunkManager::flush_file_vma(&vma);
+                let vma = vma.lock().await;
+                vma.flush_backed_file().await;
             }
         }
         Ok(())
     }
 
-    pub fn msync_by_file(&self, sync_file: &FileRef) {
+    pub async fn msync_by_file(&self, sync_file: &FileRef) {
         let current = current!();
-        let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+        let process_mem_chunks = current.vm().mem_chunks().read().await;
         let is_same_file = |file: &FileRef| -> bool { file == sync_file };
-        process_mem_chunks
-            .iter()
-            .for_each(|chunk| match chunk.internal() {
+        for chunk in process_mem_chunks.iter() {
+            match chunk.internal() {
                 ChunkType::MultiVMA(manager) => {
                     manager
                         .lock()
-                        .unwrap()
+                        .await
                         .chunk_manager_mut()
-                        .msync_by_file(sync_file);
+                        .msync_by_file(sync_file)
+                        .await;
                 }
                 ChunkType::SingleVMA(vma) => {
-                    ChunkManager::flush_file_vma_with_cond(&vma.lock().unwrap(), is_same_file);
+                    vma.lock()
+                        .await
+                        .flush_backed_file_with_cond(is_same_file)
+                        .await;
                 }
-            });
+            }
+        }
     }
 
-    pub fn mremap(&self, options: &VMRemapOptions) -> Result<usize> {
+    pub async fn mremap(&self, options: &VMRemapOptions) -> Result<usize> {
         let old_addr = options.old_addr();
         let old_size = options.old_size();
         let old_range = VMRange::new_with_size(old_addr, old_size)?;
@@ -395,12 +416,13 @@ impl VMManager {
         // Try merging all connecting chunks
         {
             // Must lock the internal manager first here in case the chunk's range and vma are conflict when other threads are operating the VM
-            let mut internal_manager = self.internal.lock().unwrap();
+            let mut internal_manager = self.internal.lock().await;
             // Lock process mem_chunks during the whole merging process to avoid conflict
-            let mut process_mem_chunks = current.vm().mem_chunks().write().unwrap();
+            let mut process_mem_chunks = current.vm().mem_chunks().write().await;
 
-            let mut merged_vmas = ProcessVM::merge_all_single_vma_chunks(&mut process_mem_chunks)?;
-            internal_manager.clean_single_vma_chunks();
+            let mut merged_vmas =
+                ProcessVM::merge_all_single_vma_chunks(&mut process_mem_chunks).await?;
+            internal_manager.clean_single_vma_chunks().await;
 
             // Add merged chunks to internal manager and process mem_chunks
             while merged_vmas.len() != 0 {
@@ -414,7 +436,7 @@ impl VMManager {
 
         // Determine the chunk of the old range
         let chunk = {
-            let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+            let process_mem_chunks = current.vm().mem_chunks().read().await;
             let chunk = process_mem_chunks
                 .iter()
                 .find(|&chunk| chunk.range().is_superset_of(&old_range));
@@ -429,17 +451,18 @@ impl VMManager {
         let remap_result_option = match chunk.internal() {
             ChunkType::MultiVMA(manager) => manager
                 .lock()
-                .unwrap()
+                .await
                 .chunk_manager_mut()
                 .parse_mremap_options(options),
             ChunkType::SingleVMA(vma) => {
                 self.parse_mremap_options_for_single_vma_chunk(options, vma)
+                    .await
             }
         }?;
         trace!("mremap options after parsing = {:?}", remap_result_option);
 
         let ret_addr = if let Some(mmap_options) = remap_result_option.mmap_options() {
-            let mmap_addr = self.mmap(mmap_options);
+            let mmap_addr = self.mmap(mmap_options).await;
 
             // FIXME: For MRemapFlags::MayMove flag, we checked if the preferred range is free when parsing the options.
             // But there is no lock after the checking, thus the mmap might fail. In this case, we should try mmap again.
@@ -461,30 +484,31 @@ impl VMManager {
 
         if let Some((munmap_addr, munmap_size)) = remap_result_option.munmap_args() {
             self.munmap(*munmap_addr, *munmap_size)
+                .await
                 .expect("Shouldn't fail");
         }
 
         return Ok(ret_addr);
     }
 
-    fn parse_mremap_options_for_single_vma_chunk(
+    async fn parse_mremap_options_for_single_vma_chunk(
         &self,
         options: &VMRemapOptions,
-        chunk_vma: &SgxMutex<VMArea>,
+        chunk_vma: &AsyncMutex<VMArea>,
     ) -> Result<VMRemapResult> {
-        let mut vm_manager = self.internal.lock().unwrap();
-        let chunk_vma = chunk_vma.lock().unwrap();
+        let mut vm_manager = self.internal.lock().await;
+        let chunk_vma = chunk_vma.lock().await;
         vm_manager.parse(options, &chunk_vma)
     }
 
     // When process is exiting, free all owned chunks
-    pub fn free_chunks_when_exit(&self, thread: &ThreadRef) {
-        let mut internal_manager = self.internal();
-        let mut mem_chunks = thread.vm().mem_chunks().write().unwrap();
+    pub async fn free_chunks_when_exit(&self, thread: &ThreadRef) {
+        let mut internal_manager = self.internal().await;
+        let mut mem_chunks = thread.vm().mem_chunks().write().await;
 
-        mem_chunks.iter().for_each(|chunk| {
-            internal_manager.munmap_chunk(&chunk, None);
-        });
+        for chunk in mem_chunks.iter() {
+            internal_manager.munmap_chunk(&chunk, None).await;
+        }
         mem_chunks.clear();
 
         assert!(mem_chunks.len() == 0);
@@ -526,12 +550,12 @@ impl InternalVMManager {
     }
 
     // Allocate a chunk with single vma
-    pub fn mmap_chunk(&mut self, options: &VMMapOptions) -> Result<ChunkRef> {
+    pub async fn mmap_chunk(&mut self, options: &VMMapOptions) -> Result<ChunkRef> {
         let addr = *options.addr();
         let size = *options.size();
         let align = *options.align();
         let free_range = self.find_free_gaps_with_random_offset(size, align, addr)?;
-        let free_chunk = Chunk::new_single_vma_chunk(&free_range, options);
+        let free_chunk = Chunk::new_single_vma_chunk(&free_range, options).await;
         if let Err(e) = free_chunk {
             // Error when creating chunks. Must return the free space before returning error
             self.free_manager
@@ -546,26 +570,53 @@ impl InternalVMManager {
 
     // Munmap a chunk
     // For Single VMA chunk, a part of the chunk could be munmapped if munmap_range is specified.
-    pub fn munmap_chunk(&mut self, chunk: &ChunkRef, munmap_range: Option<&VMRange>) -> Result<()> {
+    pub async fn munmap_chunk(
+        &mut self,
+        chunk: &ChunkRef,
+        munmap_range: Option<&VMRange>,
+    ) -> Result<()> {
         trace!(
             "munmap_chunk range = {:?}, munmap_range = {:?}",
             chunk.range(),
             munmap_range
         );
-        let vma = match chunk.internal() {
+        match chunk.internal() {
+            ChunkType::MultiVMA(_) => self.munmap_multi_vma_chunk(chunk, munmap_range).await,
+            ChunkType::SingleVMA(_) => self.munmap_single_vma_chunk(chunk, munmap_range).await,
+        }
+    }
+
+    async fn munmap_multi_vma_chunk(
+        &mut self,
+        chunk: &ChunkRef,
+        munmap_range: Option<&VMRange>,
+    ) -> Result<()> {
+        match chunk.internal() {
             ChunkType::MultiVMA(manager) => {
-                let mut manager = manager.lock().unwrap();
-                let is_cleaned = manager.clean_multi_vmas();
+                let mut manager = manager.lock().await;
+                let is_cleaned = manager.clean_multi_vmas().await;
                 // If the manager is cleaned, there is only one process using this chunk. Thus it can be freed safely.
                 // If the manager is not cleaned, there is at least another process which is using this chunk. Don't free it here.
                 if is_cleaned {
                     self.free_chunk(chunk)?;
                 }
-                return Ok(());
+            }
+            ChunkType::SingleVMA(_) => unreachable!(),
+        }
+        Ok(())
+    }
+
+    pub async fn munmap_single_vma_chunk(
+        &mut self,
+        chunk: &ChunkRef,
+        munmap_range: Option<&VMRange>,
+    ) -> Result<()> {
+        let vma = match chunk.internal() {
+            ChunkType::MultiVMA(_) => {
+                unreachable!()
             }
             ChunkType::SingleVMA(vma) => vma,
         };
-
         let munmap_range = {
             if munmap_range.is_none() {
                 chunk.range()
@@ -577,7 +628,7 @@ impl InternalVMManager {
         // Either the munmap range is a subset of the chunk range or the munmap range is
         // a superset of the chunk range. We can handle both cases.
 
-        let mut vma = vma.lock().unwrap();
+        let mut vma = vma.lock().await;
         debug_assert!(chunk.range() == vma.range());
         let intersection_vma = match vma.intersect(munmap_range) {
             Some(intersection_vma) => intersection_vma,
@@ -585,7 +636,7 @@ impl InternalVMManager {
         };
 
         // File-backed VMA needs to be flushed upon munmap
-        ChunkManager::flush_file_vma(&intersection_vma);
+        intersection_vma.flush_backed_file().await;
 
         // Reset memory permissions
         if !&intersection_vma.perms().is_default() {
@@ -610,13 +661,14 @@ impl InternalVMManager {
                 if current.status() != ThreadStatus::Exited {
                     // If the current thread is exiting, there is no need to remove the chunk from process' mem_list.
                     // It will be drained.
-                    current.vm().remove_mem_chunk(&chunk);
+                    current.vm().remove_mem_chunk(&chunk).await;
                 }
             }
             1 => {
                 // Update the current vma to the new vma
                 let updated_vma = new_vmas.pop().unwrap();
-                self.update_single_vma_chunk(&current, &chunk, updated_vma);
+                self.update_single_vma_chunk(&current, &chunk, updated_vma)
+                    .await;
 
                 // Return the intersection range to free list
                 self.free_manager
@@ -630,17 +682,18 @@ impl InternalVMManager {
                 let new_vma = new_vmas.pop().unwrap();
                 let new_vma_chunk = Arc::new(Chunk::new_chunk_with_vma(new_vma));
                 self.chunks.insert(new_vma_chunk.clone());
-                current.vm().add_mem_chunk(new_vma_chunk);
+                current.vm().add_mem_chunk(new_vma_chunk).await;
 
                 let updated_vma = new_vmas.pop().unwrap();
-                self.update_single_vma_chunk(&current, &chunk, updated_vma);
+                self.update_single_vma_chunk(&current, &chunk, updated_vma)
+                    .await;
             }
             _ => unreachable!(),
         }
         Ok(())
     }
 
-    fn update_single_vma_chunk(
+    async fn update_single_vma_chunk(
         &mut self,
         current_thread: &ThreadRef,
         old_chunk: &ChunkRef,
@@ -649,13 +702,14 @@ impl InternalVMManager {
         let new_chunk = Arc::new(Chunk::new_chunk_with_vma(new_vma));
         current_thread
             .vm()
-            .replace_mem_chunk(old_chunk, new_chunk.clone());
+            .replace_mem_chunk(old_chunk, new_chunk.clone())
+            .await;
         self.chunks.remove(old_chunk);
         self.chunks.insert(new_chunk);
     }
 
     // protect_range should a sub-range of the chunk range
-    pub fn mprotect_single_vma_chunk(
+    pub async fn mprotect_single_vma_chunk(
         &mut self,
         chunk: &ChunkRef,
         protect_range: VMRange,
@@ -670,7 +724,7 @@ impl InternalVMManager {
         };
 
         let mut updated_vmas = {
-            let mut containing_vma = vma.lock().unwrap();
+            let mut containing_vma = vma.lock().await;
             trace!(
                 "mprotect_single_vma_chunk range = {:?}, mprotect_range = {:?}",
                 chunk.range(),
@@ -752,23 +806,24 @@ impl InternalVMManager {
         // First update current vma chunk
         if updated_vmas.len() > 1 {
             let update_vma = updated_vmas.pop().unwrap();
-            self.update_single_vma_chunk(&current, &chunk, update_vma);
+            self.update_single_vma_chunk(&current, &chunk, update_vma)
+                .await;
         }
 
         // Then add new chunks if any
-        updated_vmas.into_iter().for_each(|vma| {
-            self.add_new_chunk(&current, vma);
-        });
+        for vma in updated_vmas.into_iter() {
+            self.add_new_chunk(&current, vma).await;
+        }
 
         Ok(())
     }
 
     // Must make sure that all the chunks are valid before adding new chunks
-    fn add_new_chunk(&mut self, current_thread: &ThreadRef, new_vma: VMArea) {
+    async fn add_new_chunk(&mut self, current_thread: &ThreadRef, new_vma: VMArea) {
         let new_vma_chunk = Arc::new(Chunk::new_chunk_with_vma(new_vma));
         let success = self.chunks.insert(new_vma_chunk.clone());
         debug_assert!(success);
-        current_thread.vm().add_mem_chunk(new_vma_chunk);
+        current_thread.vm().add_mem_chunk(new_vma_chunk).await;
     }
 
     pub fn free_chunk(&mut self, chunk: &ChunkRef) -> Result<()> {
@@ -797,10 +852,16 @@ impl InternalVMManager {
         );
     }
 
-    pub fn clean_single_vma_chunks(&mut self) {
-        self.chunks
-            .drain_filter(|chunk| chunk.is_single_vma_chunk_should_be_removed())
-            .collect::<BTreeSet<Arc<Chunk>>>();
+    pub async fn clean_single_vma_chunks(&mut self) {
+        let mut to_be_removed = Vec::new();
+        for chunk in self.chunks.iter() {
+            if chunk.is_single_vma_chunk_should_be_removed().await {
+                to_be_removed.push(chunk.clone());
+            }
+        }
+        for chunk in to_be_removed {
+            self.chunks.remove(&chunk);
+        }
     }
 
     // If addr is specified, use single VMA chunk to record the memory chunk.
@@ -811,14 +872,19 @@ impl InternalVMManager {
     // the unmapped memory might be allocated by other thread who is waiting and acquiring the lock.
     // Thus, in current code, this method is implemented for InternalManager and holds the lock during the whole process.
     // Below method "force_mmap_across_multiple_chunks" is the same.
-    fn mmap_with_addr(&mut self, target_range: VMRange, options: &VMMapOptions) -> Result<usize> {
+    #[async_recursion(?Send)]
+    async fn mmap_with_addr(
+        &mut self,
+        target_range: VMRange,
+        options: &VMMapOptions,
+    ) -> Result<usize> {
         let addr = *options.addr();
         let size = *options.size();
 
         let current = current!();
 
         let chunk = {
-            let process_mem_chunks = current.vm().mem_chunks().read().unwrap();
+            let process_mem_chunks = current.vm().mem_chunks().read().await;
             process_mem_chunks
                 .iter()
                 .find(|&chunk| chunk.range().intersect(&target_range).is_some())
@@ -831,7 +897,9 @@ impl InternalVMManager {
                 ChunkType::MultiVMA(chunk_internal) => {
                     if !chunk.range().is_superset_of(&target_range) && addr.is_force() {
                         // The target range spans multiple chunks and have a strong need for the address
-                        return self.force_mmap_across_multiple_chunks(target_range, options);
+                        return self
+                            .force_mmap_across_multiple_chunks(target_range, options)
+                            .await;
                     }
 
                     trace!(
@@ -840,9 +908,10 @@ impl InternalVMManager {
                     );
                     return chunk_internal
                         .lock()
-                        .unwrap()
+                        .await
                         .chunk_manager_mut()
-                        .mmap(options);
+                        .mmap(options)
+                        .await;
                 }
                 ChunkType::SingleVMA(_) => {
                     match addr {
@@ -856,11 +925,12 @@ impl InternalVMManager {
                             if !chunk.range().is_superset_of(&target_range) {
                                 // The target range spans multiple chunks and have a strong need for the address
                                 return self
-                                    .force_mmap_across_multiple_chunks(target_range, options);
+                                    .force_mmap_across_multiple_chunks(target_range, options)
+                                    .await;
                             }
 
                             // Munmap the corresponding single vma chunk
-                            self.munmap_chunk(&chunk, Some(&target_range))?;
+                            self.munmap_chunk(&chunk, Some(&target_range)).await?;
                         }
                         VMMapAddr::Any => unreachable!(),
                     }
@@ -869,7 +939,7 @@ impl InternalVMManager {
         }
 
         // This range is not currently using, allocate one in global list
-        if let Ok(new_chunk) = self.mmap_chunk(options) {
+        if let Ok(new_chunk) = self.mmap_chunk(options).await {
             let start = new_chunk.range().start();
             debug_assert!({
                 match addr {
@@ -877,14 +947,14 @@ impl InternalVMManager {
                     _ => true,
                 }
             });
-            current.vm().add_mem_chunk(new_chunk);
+            current.vm().add_mem_chunk(new_chunk).await;
             return Ok(start);
         } else {
             return_errno!(ENOMEM, "can't allocate a chunk in global list")
         }
     }
 
-    fn force_mmap_across_multiple_chunks(
+    async fn force_mmap_across_multiple_chunks(
         &mut self,
         target_range: VMRange,
         options: &VMMapOptions,
@@ -907,14 +977,13 @@ impl InternalVMManager {
                 .collect::<Vec<_>>();
 
             // If any intersect chunk belongs to other process, then this mmap can't succeed
-            if chunks
-                .iter()
-                .any(|chunk| !chunk.is_owned_by_current_process())
-            {
-                return_errno!(
-                    ENOMEM,
-                    "part of the target range is allocated by other process"
-                );
+            for chunk in chunks.iter() {
+                if !chunk.is_owned_by_current_process().await {
+                    return_errno!(
+                        ENOMEM,
+                        "part of the target range is allocated by other process"
+                    );
+                }
             }
             chunks
         };
@@ -971,7 +1040,7 @@ impl InternalVMManager {
             target_contained_ranges
         );
         for (range, options) in target_contained_ranges.into_iter().zip(new_options.iter()) {
-            if self.mmap_with_addr(range, options).is_err() {
+            if self.mmap_with_addr(range, options).await.is_err() {
                 // Although the error here is fatal and rare, returning error is not enough here.
                 // FIXME: All previous mmap ranges should be munmapped.
                 return_errno!(ENOMEM, "mmap across multiple chunks failed");


### PR DESCRIPTION
Prerequisite: Merge https://github.com/occlum/occlum/pull/1243 first

This PR asynchronizes Occlum's VM subsystem.

1. `mmap()`, `munmap()`, `mremap()`, `mprotect()`, `brk()`, `msync()`, `shmget()`, `shmdt()`, `sgmctl()`, `sysinfo()` are async functions now.
2. Do not rely `ProcessVM::Drop` for error handling, instead of hooking error handler in process spawn after VM initialized.
3. The change affects exception, signal, process, procfs, ipc subsystems.

Hw mode ci is tested [here](https://github.com/lucassong-mh/occlum/actions/runs/4817347977).