### PR TITLE
[test] Fix false alarm for cpuid test

### DIFF
--- a/test/cpuid/main.c
+++ b/test/cpuid/main.c
@@ -35,8 +35,8 @@ static bool is_cpuidinfo_equal(int leaf, t_cpuid_t *cpu, t_cpuid_t *cpu_sgx) {
                 (cpu->ecx == cpu_sgx->ecx) &&
                 (cpu->edx == cpu_sgx->edx));
     }
-    /* Leaf 0BH and 06H CPUID.EDX is related with logical processor. */
-    if (leaf == 0xB || leaf == 0x6) {
+    /* Leaf 1FH, 0BH and 06H CPUID.EDX is related with logical processor. */
+    if (leaf == 0x1F || leaf == 0xB || leaf == 0x6) {
         return ((cpu->eax == cpu_sgx->eax) &&
                 (cpu->ebx == cpu_sgx->ebx) &&
                 (cpu->ecx == cpu_sgx->ecx));


### PR DESCRIPTION
For new x86 processors, CPUID leaf 1FH is introduced as the V2 Extended Topology Enumeration and is a prefered superset to leaf 0BH.

Add extra case to skip the EDX check because the corresponding value is related with logical processor (x2APIC ID).