### PR TITLE
[libos] Replace SEFS to AsyncSFS+JinDisk as Occlum's default storage backend

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -110,7 +110,7 @@ jobs:
       if: ${{ always() }}
       run: docker stop ${{ env.CONTAINER_NAME }}
 
-  SEFS_FIO_Test:
+  FIO_Test:
     timeout-minutes: 60
     runs-on: ${{ matrix.self_runner }}
     strategy:
@@ -144,59 +144,7 @@ jobs:
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1
       with:
-        name: FIO Benchmark on SEFS
-        # What benchmark tool the output.txt came from
-        tool: 'customBiggerIsBetter'
-        # Where the output from the benchmark tool is stored
-        output-file-path: result.json
-        # Path to directory which contains benchmark files on GitHub pages branch
-        benchmark-data-dir-path: 'dev/benchmarks'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: true
-        # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '200%'
-        comment-on-alert: true
-        # Workflow will fail when an alert happens
-        fail-on-alert: true
-    - name: Clean the environment
-      if: ${{ always() }}
-      run: docker stop ${{ env.CONTAINER_NAME }}
-
-  AsyncSFS_FIO_Test:
-    timeout-minutes: 60
-    runs-on: ${{ matrix.self_runner }}
-    strategy:
-      matrix:
-        self_runner: [[self-hosted, SGX2-HW, benchmark]]
-
-    steps:
-    - name: Clean before running
-      run: |
-        sudo chown -R ${{ secrets.CI_ADMIN }} "${{ github.workspace }}"
-
-    - uses: AutoModality/action-clean@v1
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - uses: ./.github/workflows/composite_action/hw
-      with:
-        container-name: ${{ github.job }}
-        build-envs: 'OCCLUM_RELEASE_BUILD=1'
-
-    - name: Run fio download and build
-      run: docker exec ${{ env.CONTAINER_NAME }} bash -c "cd /root/occlum/demos/benchmarks/fio && ./fio_microbench.sh /sfs/fio-microbench"
-
-    - name: Copy result
-      run: docker cp ${{ env.CONTAINER_NAME }}:/root/occlum/demos/benchmarks/fio/result.json .
-
-    # Run `github-action-benchmark` action
-    - name: Store benchmark result
-      uses: benchmark-action/github-action-benchmark@v1
-      with:
-        name: FIO Benchmark on AsyncSFS and JinDisk
+        name: FIO Benchmark (AsyncSFS + JinDisk)
         # What benchmark tool the output.txt came from
         tool: 'customBiggerIsBetter'
         # Where the output from the benchmark tool is stored

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Integration test with Glibc
       run:  docker exec ${{ github.job }} bash -c "cd /root/occlum; OCCLUM_LOG_LEVEL=trace SGX_MODE=SIM make test-glibc"
 
+    - name: Integration test with legacy Occlum configuration (SEFS)
+      run:  docker exec ${{ github.job }} bash -c "cd /root/occlum/test; OCCLUM_LOG_LEVEL=trace SGX_MODE=SIM make test-legacy"
+
     - name: Show failed cases
       if: ${{ failure() }}
       run: docker exec ${{ github.job }} bash -c "cat /root/occlum/build/test/.fail"

--- a/demos/benchmarks/filebench/run_workload.sh
+++ b/demos/benchmarks/filebench/run_workload.sh
@@ -23,8 +23,7 @@ copy_bom -f ../filebench.yaml --root image --include-dir /opt/occlum/etc/templat
 # Enlarge "user_space_size" when "procflow exec proc failed" occurs
 yq '.resource_limits.user_space_size.init = "2000MB" |
     .resource_limits.kernel_space_heap_size.init ="1000MB" |
-    .resource_limits.kernel_space_heap_size.max ="1000MB" |
-    .mount += [{"target": "/sfs", "type": "async_sfs", "source": "./run/async_sfs_image", "options": {"async_sfs_total_size": "5GB", "page_cache_size": "256MB"}}] ' -i Occlum.yaml
+    .resource_limits.kernel_space_heap_size.max ="1000MB" ' -i Occlum.yaml
 
 occlum build
 

--- a/demos/benchmarks/fio/run_fio_on_occlum.sh
+++ b/demos/benchmarks/fio/run_fio_on_occlum.sh
@@ -28,8 +28,7 @@ rm -rf occlum_instance && occlum new occlum_instance
 cd occlum_instance
 yq '.resource_limits.user_space_size.init = "320MB" |
     .resource_limits.kernel_space_heap_size.init = "800MB" |
-    .resource_limits.kernel_space_heap_size.max = "800MB" |
-    .mount += [{"target": "/sfs", "type": "async_sfs", "source": "./run/async_sfs_image", "options": {"async_sfs_total_size": "5GB", "page_cache_size": "256MB"}}] ' -i Occlum.yaml
+    .resource_limits.kernel_space_heap_size.max = "800MB" ' -i Occlum.yaml
 
 # 2. Copy files into Occlum instance and build
 rm -rf image

--- a/demos/fish/run_fish_test.sh
+++ b/demos/fish/run_fish_test.sh
@@ -9,7 +9,7 @@ occlum new occlum-instance
 cd occlum-instance
 
 yq '.resource_limits.user_space_size.init = "512MB" |
-    .resource_limits.kernel_space_heap_size.init = "64MB" |
+    .resource_limits.kernel_space_heap_size.init = "512MB" |
     .env.default = [ "OCCLUM=yes", "HOME=/root" ]' -i Occlum.yaml
 
 rm -rf image

--- a/demos/fish/run_per_process_config_test.sh
+++ b/demos/fish/run_per_process_config_test.sh
@@ -11,7 +11,7 @@ occlum new occlum-test && cd occlum-test
 
 # Set process memory space size to very small values and will fail when running target script using default configuration
 yq '.resource_limits.user_space_size.init = "512MB" |
-    .resource_limits.kernel_space_heap_size.init= "64MB" |
+    .resource_limits.kernel_space_heap_size.init= "512MB" |
     .process.default_stack_size = "1MB" |
     .process.default_heap_size = "1MB" |
     .env.default = [ "OCCLUM=yes", "HOME=/root" ]' -i Occlum.yaml

--- a/demos/flink/run_flink_on_occlum_glibc.sh
+++ b/demos/flink/run_flink_on_occlum_glibc.sh
@@ -17,7 +17,7 @@ init_instance() {
     occlum init
     yq '.resource_limits.user_space_size.init = "5500MB" |
         .process.default_heap_size = "128MB" |
-        .resource_limits.kernel_space_heap_size.init="64MB" |
+        .resource_limits.kernel_space_heap_size.init="512MB" |
         .entry_points = [ "/usr/lib/jvm/java-11-openjdk-amd64/bin" ] |
         .mount += [{"target": "/host", "type": "hostfs", "source": "."}] |
         .env.default = [ "LD_LIBRARY_PATH=/usr/lib/jvm/java-11-openjdk-amd64/lib/server:/usr/lib/jvm/java-11-openjdk-amd64/lib:/usr/lib/jvm/java-11-openjdk-amd64/../lib:/lib" ]' \

--- a/demos/font/font_support_for_java/run_java_font_app_internal.sh
+++ b/demos/font/font_support_for_java/run_java_font_app_internal.sh
@@ -19,7 +19,7 @@ init_instance() {
     cd occlum_instance
     occlum init
     yq '.resource_limits.user_space_size.init = "1400MB" |
-        .resource_limits.kernel_space_heap_size.init="64MB" |
+        .resource_limits.kernel_space_heap_size.init="512MB" |
         .process.default_heap_size = "256MB" |
         .entry_points = [ "/usr/lib/jvm/java-11-alibaba-dragonwell/jre/bin" ] |
         .env.default = [ "LD_LIBRARY_PATH=/usr/lib/jvm/java-11-alibaba-dragonwell/jre/lib/server:/usr/lib/jvm/java-11-alibaba-dragonwell/jre/lib:/usr/lib/jvm/java-11-alibaba-dragonwell/jre/../lib" ]' \

--- a/demos/golang/go_sqlite/run_go_sqlite_demo.sh
+++ b/demos/golang/go_sqlite/run_go_sqlite_demo.sh
@@ -17,7 +17,7 @@ rm -rf simple_demo_instance && mkdir simple_demo_instance
 cd simple_demo_instance
 occlum init
 yq '.resource_limits.user_space_size.init = "2560MB" |
-	.resource_limits.kernel_space_heap_size.init="320MB" |
+	.resource_limits.kernel_space_heap_size.init="512MB" |
 	.resource_limits.kernel_space_stack_size="10MB" |
 	.process.default_stack_size = "40MB" |
 	.process.default_heap_size = "320MB" ' -i Occlum.yaml

--- a/demos/golang/grpc_pingpong/run_ping_on_occlum.sh
+++ b/demos/golang/grpc_pingpong/run_ping_on_occlum.sh
@@ -17,7 +17,7 @@ rm -rf occlum_ping_instance && mkdir occlum_ping_instance
 cd occlum_ping_instance
 occlum init
 yq '.resource_limits.user_space_size.init = "800MB" |
-	.resource_limits.kernel_space_heap_size.init ="40MB" |
+	.resource_limits.kernel_space_heap_size.init ="512MB" |
 	.resource_limits.kernel_space_stack_size="1MB" |
 	.process.default_stack_size = "1MB" |
 	.process.default_heap_size = "20MB" ' -i Occlum.yaml

--- a/demos/golang/grpc_pingpong/run_pong_on_occlum.sh
+++ b/demos/golang/grpc_pingpong/run_pong_on_occlum.sh
@@ -17,7 +17,7 @@ rm -rf occlum_pong_instance && mkdir occlum_pong_instance
 cd occlum_pong_instance
 occlum init
 yq '.resource_limits.user_space_size.init = "800MB" |
-	.resource_limits.kernel_space_heap_size.init ="40MB" |
+	.resource_limits.kernel_space_heap_size.init ="512MB" |
 	.resource_limits.kernel_space_stack_size="1MB" |
 	.process.default_stack_size = "1MB" |
 	.process.default_heap_size = "20MB" ' -i Occlum.yaml

--- a/demos/golang/vault/run_occlum_vault_server.sh
+++ b/demos/golang/vault/run_occlum_vault_server.sh
@@ -17,7 +17,7 @@ rm -rf occlum_instance
 occlum new occlum_instance
 cd occlum_instance
 yq '.resource_limits.user_space_size.init = "2560MB" |
-	.resource_limits.kernel_space_heap_size.init ="320MB" |
+	.resource_limits.kernel_space_heap_size.init ="512MB" |
 	.resource_limits.kernel_space_stack_size="10MB" |
 	.process.default_stack_size = "40MB" |
 	.process.default_heap_size = "320MB" ' -i Occlum.yaml

--- a/demos/java/run_java_on_occlum.sh
+++ b/demos/java/run_java_on_occlum.sh
@@ -25,7 +25,7 @@ init_instance() {
     cd occlum_instance
     occlum init
     yq '.resource_limits.user_space_size.init = "1680MB" |
-        .resource_limits.kernel_space_heap_size.init="64MB" |
+        .resource_limits.kernel_space_heap_size.init="512MB" |
         .process.default_heap_size = "256MB" |
         .entry_points = [ "/usr/lib/jvm/java-11-alibaba-dragonwell/jre/bin" ] |
         .env.default = [ "LD_LIBRARY_PATH=/usr/lib/jvm/java-11-alibaba-dragonwell/jre/lib/server:/usr/lib/jvm/java-11-alibaba-dragonwell/jre/lib:/usr/lib/jvm/java-11-alibaba-dragonwell/jre/../lib" ]' \

--- a/demos/linux-ltp/.gitignore
+++ b/demos/linux-ltp/.gitignore
@@ -1,0 +1,3 @@
+ltp
+ltp_install
+ltp_instance

--- a/demos/linux-ltp/prepare_ltp.sh
+++ b/demos/linux-ltp/prepare_ltp.sh
@@ -1,10 +1,9 @@
 #! /bin/bash
 set -e
 
-rm -rf ltp_instance
-occlum new ltp_instance
+rm -rf ltp_instance && mkdir ltp_instance && cd ltp_instance
+occlum init --use-sefs
 
-cd ltp_instance
 rm -rf image
 copy_bom -f ../ltp.yaml --root image --include-dir /opt/occlum/etc/template
 

--- a/demos/mysql/run_mysql_server.sh
+++ b/demos/mysql/run_mysql_server.sh
@@ -15,8 +15,9 @@ rm -rf occlum_instance && occlum new occlum_instance
 pushd occlum_instance
 
 yq '.resource_limits.user_space_size.init = "8000MB" |
-    .resource_limits.kernel_space_heap_size.init = "1000MB" |
-    .resource_limits.kernel_space_heap_size.max = "2000MB" ' -i Occlum.yaml
+    .resource_limits.kernel_space_heap_size.init = "2500MB" |
+    .resource_limits.kernel_space_heap_size.max = "2500MB" |
+    .mount[0].options.layers[1].options.async_sfs_total_size = "35GB" ' -i Occlum.yaml
 
 # 2. Copy files into Occlum instance and build
 rm -rf image

--- a/demos/paddlepaddle/run_paddlepaddle_on_occlum.sh
+++ b/demos/paddlepaddle/run_paddlepaddle_on_occlum.sh
@@ -16,7 +16,7 @@ if [ ! -d $python_dir ];then
 fi
 
 yq '.resource_limits.user_space_size.init = "6000MB" |
-    .resource_limits.kernel_space_heap_size.init = "256MB" |
+    .resource_limits.kernel_space_heap_size.init = "512MB" |
     .env.default += ["PYTHONHOME=/opt/python-occlum"]' -i Occlum.yaml
 
 occlum build

--- a/demos/python/flask/build_occlum_instance.sh
+++ b/demos/python/flask/build_occlum_instance.sh
@@ -17,7 +17,7 @@ if [ ! -d $python_dir ];then
 fi
 
 yq '.resource_limits.user_space_size.init = "640MB" |
-    .resource_limits.kernel_space_heap_size.init = "256MB" |
+    .resource_limits.kernel_space_heap_size.init = "512MB" |
     .env.default += ["PYTHONHOME=/opt/python-occlum"]' -i Occlum.yaml
 
 occlum build

--- a/demos/python/python_glibc/run_python_on_occlum.sh
+++ b/demos/python/python_glibc/run_python_on_occlum.sh
@@ -18,7 +18,7 @@ if [ ! -d $python_dir ];then
 fi
 
 yq '.resource_limits.user_space_size.init = "640MB" |
-    .resource_limits.kernel_space_heap_size.init = "300MB" |
+    .resource_limits.kernel_space_heap_size.init = "512MB" |
     .env.default += ["PYTHONHOME=/opt/python-occlum"] |
     .mount += [{"target": "/host", "type": "hostfs", "source": "."}]' -i Occlum.yaml
 

--- a/demos/python/python_musl/run_python_on_occlum.sh
+++ b/demos/python/python_musl/run_python_on_occlum.sh
@@ -21,7 +21,7 @@ if [ ! -d "image/lib/python3.7" ];then
     rm -rf image
     copy_bom -f ../python_musl.yaml --root image --include-dir /opt/occlum/etc/template
     yq '.resource_limits.user_space_size.init = "320MB" |
-        .resource_limits.kernel_space_heap_size.init = "256MB" |
+        .resource_limits.kernel_space_heap_size.init = "512MB" |
         .mount += [{"target": "/host", "type": "hostfs", "source": "."}] ' -i Occlum.yaml
 
     occlum build

--- a/demos/pytorch/run_pytorch_on_occlum.sh
+++ b/demos/pytorch/run_pytorch_on_occlum.sh
@@ -16,7 +16,7 @@ if [ ! -d $python_dir ];then
 fi
 
 yq '.resource_limits.user_space_size.init = "6000MB" |
-    .resource_limits.kernel_space_heap_size.init = "256MB" |
+    .resource_limits.kernel_space_heap_size.init = "512MB" |
     .env.default += ["PYTHONHOME=/opt/python-occlum"]' -i Occlum.yaml
 
 occlum build

--- a/demos/remote_attestation/azure_attestation/maa_attestation/build.sh
+++ b/demos/remote_attestation/azure_attestation/maa_attestation/build.sh
@@ -18,7 +18,7 @@ function build() {
     rm -rf image
     copy_bom -f $bomfile --root image --include-dir /opt/occlum/etc/template
     yq '.resource_limits.user_space_size.init = "600MB" |
-        .resource_limits.kernel_space_heap_size.init = "128MB"' -i Occlum.yaml
+        .resource_limits.kernel_space_heap_size.init = "512MB" ' -i Occlum.yaml
 
     occlum build
 

--- a/demos/remote_attestation/init_ra_flow/build_content.sh
+++ b/demos/remote_attestation/init_ra_flow/build_content.sh
@@ -50,7 +50,7 @@ function build_client_instance()
     copy_bom -f ../flask.yaml --root image --include-dir /opt/occlum/etc/template
 
     yq '.resource_limits.user_space_size.init = "600MB" |
-        .resource_limits.kernel_space_heap_size.init = "128MB" |
+        .resource_limits.kernel_space_heap_size.init = "512MB" |
         .metadata.debuggable = false |
         .metadata.enable_kss = true |
         .metadata.version_number = 88 |

--- a/demos/rocksdb/run_benchmark.sh
+++ b/demos/rocksdb/run_benchmark.sh
@@ -11,8 +11,7 @@ copy_bom -f ../rocksdb.yaml --root image --include-dir /opt/occlum/etc/template
 
 yq '.resource_limits.user_space_size.init = "1024MB" |
     .resource_limits.kernel_space_heap_size.init ="800MB" |
-    .resource_limits.kernel_space_heap_size.max ="800MB" |
-    .mount += [{"target": "/sfs", "type": "async_sfs", "source": "./run/async_sfs_image", "options": {"async_sfs_total_size": "5GB", "page_cache_size": "256MB"}}] ' -i Occlum.yaml
+    .resource_limits.kernel_space_heap_size.max ="800MB" ' -i Occlum.yaml
 
 occlum build
 

--- a/demos/runtime_boot/.gitignore
+++ b/demos/runtime_boot/.gitignore
@@ -1,0 +1,2 @@
+gen_rootfs_instance
+boot_instance

--- a/demos/sofaboot/run_sofaboot_on_occlum.sh
+++ b/demos/sofaboot/run_sofaboot_on_occlum.sh
@@ -18,7 +18,7 @@ init_instance() {
     rm -rf occlum_instance && occlum new occlum_instance
     cd occlum_instance
     yq '.resource_limits.user_space_size.init = "1680MB" |
-        .resource_limits.kernel_space_heap_size.init="64MB" |
+        .resource_limits.kernel_space_heap_size.init="512MB" |
         .process.default_heap_size = "256MB" |
         .entry_points = [ "/usr/lib/jvm/java-11-alibaba-dragonwell/jre/bin" ] |
         .env.default = [ "LD_LIBRARY_PATH=/usr/lib/jvm/java-11-alibaba-dragonwell/jre/lib/server:/usr/lib/jvm/java-11-alibaba-dragonwell/jre/lib:/usr/lib/jvm/java-11-alibaba-dragonwell/jre/../lib" ]' \

--- a/demos/sofaboot/run_sofaboot_on_occlum_jdk8.sh
+++ b/demos/sofaboot/run_sofaboot_on_occlum_jdk8.sh
@@ -18,7 +18,7 @@ init_instance() {
     rm -rf occlum_instance && occlum new occlum_instance
     cd occlum_instance
     yq '.resource_limits.user_space_size.init = "1680MB" |
-        .resource_limits.kernel_space_heap_size.init="64MB" |
+        .resource_limits.kernel_space_heap_size.init="512MB" |
         .process.default_heap_size = "256MB" |
         .entry_points = [ "/usr/lib/jvm/java-1.8-openjdk/jre/bin" ] |
         .env.default = [ "LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8-openjdk/jre/lib:/usr/lib/jvm/java-1.8-openjdk/lib" ]' \

--- a/demos/tensorflow/tensorflow_serving/run_occlum_tf_serving.sh
+++ b/demos/tensorflow/tensorflow_serving/run_occlum_tf_serving.sh
@@ -19,7 +19,7 @@ mkdir occlum_instance
 cd occlum_instance
 occlum init
 yq '.resource_limits.user_space_size.init = "7000MB" |
-    .resource_limits.kernel_space_heap_size.init="384MB" |
+    .resource_limits.kernel_space_heap_size.init="1024MB" |
     .process.default_heap_size = "128MB" |
     .env.default = [ "OMP_NUM_THREADS=8", "KMP_AFFINITY=verbose,granularity=fine,compact,1,0", "KMP_BLOCKTIME=20", "MKL_NUM_THREADS=8"]' \
     -i Occlum.yaml

--- a/demos/tensorflow/tensorflow_training/run_tensorflow_on_occlum.sh
+++ b/demos/tensorflow/tensorflow_training/run_tensorflow_on_occlum.sh
@@ -20,7 +20,7 @@ if [ ! -L "image/bin/python3" ];then
     rm -rf image
     copy_bom -f ../tensorflow_training.yaml --root image --include-dir /opt/occlum/etc/template
     yq '.resource_limits.user_space_size.init = "5400MB" |
-        .resource_limits.kernel_space_heap_size.init = "512MB" |
+        .resource_limits.kernel_space_heap_size.init = "1024MB" |
         .env.default += ["PYTHONHOME=/opt/python-occlum", "OMP_NUM_THREADS=1"]' \
         -i Occlum.yaml
 

--- a/docs/readthedocs/docs/source/filesystem/mount.md
+++ b/docs/readthedocs/docs/source/filesystem/mount.md
@@ -56,19 +56,23 @@ Apps running inside Occlum can mount some specific file systems via the [mount()
 
 Currently, we only support to create a new mount with the trusted UnionFS consisting of SEFSs or the untrusted HostFS. The mount point is not allowed to be the root directory("/").
 
-#### 1. Mount trusted UnionFS consisting of SEFSs
+#### 1. Mount trusted UnionFS consisting of FSs
 Example code:
 
 ```
 mount("unionfs", "<target_dir>", "unionfs", 0/* mountflags is ignored */,
-      "lowerdir=<lower>,upperdir=<upper>,key=<128-bit-key>")
+      "lowerdir=<lower>,lowerfs=<fs_type>,upperdir=<upper>,upperfs=<fs_type>,key=<128-bit-key>,sfssize=<size>,cachesize=<size>")
 ```
 
 Mount options:
 
-- The `lowerdir=<lower>` is a mandatory field, which describes the directory path of the RO SEFS on Host OS.
-- The `upperdir=<upper>` is a mandatory field, which describes the directory path of the RW SEFS on Host OS.
+- The `lowerdir=<lower>` is a mandatory field, which describes the directory path of the RO FS on Host OS.
+- The `lowerfs=<fs_type>` is a mandatory field, which describes the type of the RO FS. (Support SEFS/AsyncSFS by now)
+- The `upperdir=<upper>` is a mandatory field, which describes the directory path of the RW FS on Host OS.
+- The `upperfs=<fs_type>` is a mandatory field, which describes the type of the RW FS. (Support SEFS/AsyncSFS by now)
 - The `key=<128-bit-key>` is an optional field, which describes the 128bit key used to encrypt or decrypt the FS. Here is an example of the key: `key=c7-32-b3-ed-44-df-ec-7b-25-2d-9a-32-38-8d-58-61`. If this field is not provided, it will use the automatic key derived from the enclave sealing key.
+- The `sfssize=<size>` is an optional field, which describes the total size of AsyncSFS.
+- The `cachesize=<size>` is an optional field, which describes the size of page cache used by AsyncSFS.
 
 #### 2. Mount untrusted HostFS
 Example code:

--- a/etc/template/Occlum-legacy.yaml
+++ b/etc/template/Occlum-legacy.yaml
@@ -9,7 +9,7 @@ resource_limits:
   # Without EDMM support, increase the "init" field if memory insufficiency occurs. And the "max" field is ignored.
   kernel_space_heap_size:
     # Reserved and committed during the initialization stage. The more, the longer it takes to initialize.
-    init: 512MB
+    init: 32MB
     # Only committed when necessary. Only valid with EDMM support.
     max:  512MB
   # The total size of enclave memory available to the user applications running in LibOS.
@@ -101,20 +101,18 @@ mount:
             MAC: ''
         # The read-write layer whose content is produced when running the LibOS
         - target: /
-          type: async_sfs
+          type: sefs
           source: ./run/mount/__ROOT
-          options:
-            # Total size that Async-SFS can manage. Must be specified.
-            async_sfs_total_size: 10GB
-            # Page cache size that Async-SFS can use. Must be specified.
-            # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
-            page_cache_size: 256MB
-            # The JinDisk under Async-SFS uses MRSIGNER to derive key by default, so the data can
-            # be shared between same enclave signer on the same machine.
-            # If you want more secure scheme, you can set the autokey_policy field
-            # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
-            # So the data can only be accessed by the enclave itself.
-            # autokey_policy: 1
+          # options:
+          # The SEFS just uses MRSIGNER to derive key by default, so the data can
+          # be shared between same enclave signer on the same machine.
+          # If you want more secure scheme, you can set the autokey_policy field
+          # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
+          # So the data can only be accessed by the enclave itself.
+          #  autokey_policy: 1
+          # The SEFS internal cache size, increasing it will bring better file I/O 
+          # performance but also consume Occlum's kernel heap size.
+          #  sefs_cache_size: 192KB
   #
   # HostFS mount
   # It provides a channel to exchange files between Host FS and LibOS FS.
@@ -128,20 +126,22 @@ mount:
   #   type: hostfs
   #   source: .
   #
-  # SEFS mount
-  # - target: /sefs
-  #   type: sefs
-  #   source: ./run
+  # Async FS mount
+  # - target: /sfs
+  #   type: async_sfs
+  #   source: ./run/async_sfs_image
   #   options:
-  #     # The SEFS just uses MRSIGNER to derive key by default, so the data can
+  #     # Total size that Async-SFS can manage. Must be specified.
+  #     async_sfs_total_size: 4GB
+  #     # Page cache size that Async-SFS can use. Must be specified.
+  #     # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
+  #     page_cache_size: 256MB
+  #     # The JinDisk under Async-SFS uses MRSIGNER to derive key by default, so the data can
   #     # be shared between same enclave signer on the same machine.
   #     # If you want more secure scheme, you can set the autokey_policy field
   #     # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
   #     # So the data can only be accessed by the enclave itself.
   #     autokey_policy: 1
-  #     # The SEFS internal cache size, increasing it will bring better file I/O 
-  #     # performance but also consume Occlum's kernel heap size.
-  #     sefs_cache_size: 192KB
 #
 # Untrusted Unix domain socket
 # Besides the common Unix domain socket support that both ends are created in the same

--- a/src/libos/Cargo.lock
+++ b/src/libos/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "async-sfs",
  "async-socket",
  "async-trait",
+ "async-unionfs",
  "async-vfs",
  "atomic",
  "bitflags",
@@ -211,6 +212,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.99",
+]
+
+[[package]]
+name = "async-unionfs"
+version = "0.1.0"
+dependencies = [
+ "async-io",
+ "async-rt",
+ "async-trait",
+ "async-vfs",
+ "cfg-if",
+ "errno",
+ "libc",
+ "log",
+ "sgx_libc",
+ "sgx_trts",
+ "sgx_tstd",
+ "sgx_types",
 ]
 
 [[package]]

--- a/src/libos/Cargo.toml
+++ b/src/libos/Cargo.toml
@@ -13,6 +13,7 @@ async-io  = { path = "crates/async-io", features = ["sgx"] }
 async-vfs = { path = "crates/async-vfs", features = ["sgx"] }
 async-sfs = { path = "crates/async-sfs", default-features = false, features = ["sgx"] }
 async-mountfs = { path = "crates/async-mountfs", features = ["sgx"] }
+async-unionfs = { path = "crates/async-unionfs", features = ["sgx"] }
 async-trait = "0.1.52"
 async-recursion = "1.0.4"
 atomic = "0.5"

--- a/src/libos/crates/async-sfs/src/fs.rs
+++ b/src/libos/crates/async-sfs/src/fs.rs
@@ -377,6 +377,8 @@ impl AsyncInode for Inode {
                 FileType::File | FileType::SymLink | FileType::Dir => disk_inode.size as usize,
                 FileType::CharDevice => 0,
                 FileType::BlockDevice => 0,
+                FileType::NamedPipe => 0,
+                FileType::Socket => 0,
             },
             mode: 0o777,
             type_: VfsFileType::from(disk_inode.type_.clone()),
@@ -488,7 +490,7 @@ impl AsyncInode for Inode {
         let inode = {
             let fs = inner_mut.fs();
             match type_ {
-                VfsFileType::File => fs.new_inode_file().await?,
+                VfsFileType::File | VfsFileType::Socket => fs.new_inode_file().await?,
                 VfsFileType::SymLink => fs.new_inode_symlink().await?,
                 VfsFileType::Dir => fs.new_inode_dir(inner_mut.id).await?,
                 _ => return_errno!(EINVAL, "invalid type"),

--- a/src/libos/crates/async-sfs/src/metadata.rs
+++ b/src/libos/crates/async-sfs/src/metadata.rs
@@ -141,11 +141,13 @@ pub enum FileType {
     SymLink = 3,
     CharDevice = 4,
     BlockDevice = 5,
+    NamedPipe = 6,
+    Socket = 7,
 }
 
 impl From<u32> for FileType {
     fn from(t: u32) -> Self {
-        if t < Self::File as u32 || t > Self::BlockDevice as u32 {
+        if t < Self::File as u32 || t > Self::Socket as u32 {
             panic!("invalid type");
         }
         unsafe { core::mem::transmute(t) }
@@ -160,6 +162,8 @@ impl From<FileType> for VfsFileType {
             FileType::Dir => VfsFileType::Dir,
             FileType::CharDevice => VfsFileType::CharDevice,
             FileType::BlockDevice => VfsFileType::BlockDevice,
+            FileType::NamedPipe => VfsFileType::NamedPipe,
+            FileType::Socket => VfsFileType::Socket,
         }
     }
 }
@@ -172,7 +176,9 @@ impl From<VfsFileType> for FileType {
             VfsFileType::Dir => FileType::Dir,
             VfsFileType::CharDevice => FileType::CharDevice,
             VfsFileType::BlockDevice => FileType::BlockDevice,
-            _ => panic!("unknown file type"),
+            VfsFileType::NamedPipe => FileType::NamedPipe,
+            VfsFileType::Socket => FileType::Socket,
+            // _ => panic!("unknown file type"),
         }
     }
 }

--- a/src/libos/crates/jindisk/src/jindisk.rs
+++ b/src/libos/crates/jindisk/src/jindisk.rs
@@ -315,7 +315,7 @@ impl JinDisk {
             )?;
             buf.copy_from_slice(&decrypted);
         } else {
-            // error!("[JinDisk] Read nothing! Target lba: {:?}", target_lba);
+            // error!("[JinDisk] Read nothing! Target lba: {:?}", target_lba); // Allow empty read
         }
 
         Ok(buf.len())
@@ -336,11 +336,8 @@ impl JinDisk {
 
         // Search lsm tree
         let searched_records = self.lsm_tree.search_range(query_ctx).await;
-        debug_assert!(
-            query_ctx.is_completed(),
-            "Range query still not completed: {:?}",
-            query_ctx
-        );
+        // debug_assert!(query_ctx.is_completed(),
+        //     "Range query still not completed: {:?}", query_ctx); // Allow empty read
 
         // Handle negative records
         let mut searched_records: Vec<Record> = searched_records

--- a/src/libos/crates/page-cache/src/page_alloc.rs
+++ b/src/libos/crates/page-cache/src/page_alloc.rs
@@ -2,7 +2,7 @@ use crate::page::PAGE_SIZE;
 
 use std::alloc::{alloc, dealloc, Layout};
 use std::fmt::{Debug, Formatter};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// A page allocator that can allocate/deallocate pages from free memory
 /// and monitor the amount of free memory.
@@ -15,7 +15,7 @@ pub trait PageAlloc: Send + Sync + Clone + 'static {
     unsafe fn dealloc_page(page_ptr: *mut u8);
 
     /// Triggered when memory is low.
-    fn register_low_memory_callback(f: impl Fn());
+    fn register_low_memory_callback(f: impl Fn() + Send + Sync + 'static);
 
     /// Whether the memory is consumed out.
     /// User can define own memory limit.
@@ -24,48 +24,56 @@ pub trait PageAlloc: Send + Sync + Clone + 'static {
 
 /// A test-purpose page allocator with fixed total size.
 pub struct FixedSizePageAlloc {
-    total_bytes: AtomicUsize,
-    remain_bytes: AtomicUsize,
+    total_bytes: u64,
+    remain_bytes: u64,
+    on_mem_low: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
 }
 
 impl FixedSizePageAlloc {
     pub fn new(total_bytes: usize) -> Self {
         let new_self = Self {
-            total_bytes: AtomicUsize::new(total_bytes),
-            remain_bytes: AtomicUsize::new(total_bytes),
+            total_bytes: total_bytes as _,
+            remain_bytes: total_bytes as _,
+            on_mem_low: None,
         };
         trace!("[PageAlloc] new, {:#?}", new_self);
         new_self
     }
 
-    pub fn alloc_page(&self) -> *mut u8 {
-        if self.remain_bytes.load(Ordering::Relaxed) < PAGE_SIZE {
+    pub fn alloc_page(&mut self) -> *mut u8 {
+        if self.is_memory_low() {
+            self.on_mem_low
+                .as_ref()
+                .map(|low_mem_callback| low_mem_callback());
             return std::ptr::null_mut();
         }
-        self.remain_bytes.fetch_sub(PAGE_SIZE, Ordering::Relaxed);
+        self.remain_bytes = self.remain_bytes.saturating_sub(PAGE_SIZE as _);
         unsafe { alloc(self.page_layout()) }
     }
 
-    pub unsafe fn dealloc_page(&self, page_ptr: *mut u8) {
-        self.remain_bytes.fetch_add(PAGE_SIZE, Ordering::Relaxed);
+    pub unsafe fn dealloc_page(&mut self, page_ptr: *mut u8) {
+        self.remain_bytes = self.remain_bytes.saturating_add(PAGE_SIZE as _);
         dealloc(page_ptr, self.page_layout())
     }
 
-    /// Calculate current memory consumption.
-    /// Return true if 90 percent capacity has been consumed.
+    /// Check whether memory consumption reaches a low watermark.
     pub fn is_memory_low(&self) -> bool {
-        let alloc_limit: usize = self.total_bytes.load(Ordering::Relaxed) / 10;
-        if self.remain_bytes.load(Ordering::Relaxed) < alloc_limit {
+        const ALLOC_LIMIT: u64 = (2 * PAGE_SIZE) as _;
+        if self.remain_bytes < ALLOC_LIMIT {
             trace!("[PageAlloc] memory low, {:#?}", self);
             return true;
         }
         false
     }
 
-    pub fn define_limit(&self, total_bytes: usize) {
-        self.total_bytes.store(total_bytes, Ordering::Relaxed);
-        self.remain_bytes.store(total_bytes, Ordering::Relaxed);
-        trace!("[PageAlloc] define size limit, {:#?}", self);
+    pub fn register_low_memory_callback(&mut self, f: impl Fn() + Send + Sync + 'static) {
+        let _ = self.on_mem_low.insert(Arc::new(f));
+    }
+
+    pub fn raise_alloc_limit(&mut self, num_bytes: usize) {
+        self.total_bytes = self.total_bytes.saturating_add(num_bytes as _);
+        self.remain_bytes = self.remain_bytes.saturating_add(num_bytes as _);
+        trace!("[PageAlloc] raise alloc limit, {:#?}", self);
     }
 
     #[inline]
@@ -79,8 +87,7 @@ impl Debug for FixedSizePageAlloc {
         write!(
             f,
             "FixedSizePageAlloc {{ total_bytes: {}, remain_bytes: {} }}",
-            self.total_bytes.load(Ordering::Relaxed),
-            self.remain_bytes.load(Ordering::Relaxed)
+            self.total_bytes, self.remain_bytes
         )
     }
 }
@@ -97,32 +104,34 @@ macro_rules! impl_fixed_size_page_alloc {
         lazy_static::lazy_static! {
             /// A global fixed-size page allocator.
             /// The size limit should be user-defined later.
-            pub static ref GLOBAL_FIXED_SIZE_PAGE_ALLOC: $crate::FixedSizePageAlloc
-                = $crate::FixedSizePageAlloc::new(0);
+            pub static ref GLOBAL_FIXED_SIZE_PAGE_ALLOC: spin::Mutex<$crate::FixedSizePageAlloc>
+                = spin::Mutex::new($crate::FixedSizePageAlloc::new(0));
         }
 
-        GLOBAL_FIXED_SIZE_PAGE_ALLOC.define_limit($total_bytes);
+        GLOBAL_FIXED_SIZE_PAGE_ALLOC
+            .lock()
+            .raise_alloc_limit($total_bytes);
 
         #[derive(Clone)]
         pub struct $page_alloc;
 
         impl $crate::PageAlloc for $page_alloc {
             fn alloc_page() -> *mut u8 {
-                GLOBAL_FIXED_SIZE_PAGE_ALLOC.alloc_page()
+                GLOBAL_FIXED_SIZE_PAGE_ALLOC.lock().alloc_page()
             }
 
             unsafe fn dealloc_page(page_ptr: *mut u8) {
-                GLOBAL_FIXED_SIZE_PAGE_ALLOC.dealloc_page(page_ptr);
+                GLOBAL_FIXED_SIZE_PAGE_ALLOC.lock().dealloc_page(page_ptr);
             }
 
-            fn register_low_memory_callback(f: impl Fn()) {
-                if GLOBAL_FIXED_SIZE_PAGE_ALLOC.is_memory_low() {
-                    f();
-                }
+            fn register_low_memory_callback(f: impl Fn() + Send + Sync + 'static) {
+                GLOBAL_FIXED_SIZE_PAGE_ALLOC
+                    .lock()
+                    .register_low_memory_callback(f)
             }
 
             fn is_memory_low() -> bool {
-                GLOBAL_FIXED_SIZE_PAGE_ALLOC.is_memory_low()
+                GLOBAL_FIXED_SIZE_PAGE_ALLOC.lock().is_memory_low()
             }
         }
     };

--- a/src/libos/crates/page-cache/src/page_cache.rs
+++ b/src/libos/crates/page-cache/src/page_cache.rs
@@ -66,14 +66,14 @@ impl<K: PageKey, A: PageAlloc> PageCache<K, A> {
             return Some(page_handle_incache.clone());
         // Cache miss
         } else {
+            self.0.pollee.reset_events();
             // Cache miss and a new page is allocated
             if let Some(page_handle) = PageHandle::new(key) {
                 cache.put(key.into(), page_handle.clone());
                 return Some(page_handle);
             }
+            // Cache miss and no free space for new page
         }
-        // Cache miss and no free space for new page
-        self.0.pollee.reset_events();
         None
     }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,14 +17,17 @@ FAIL_LOG = $(BUILD_DIR)/test/.fail
 
 # Dependencies: need to be compiled but not to run by any Makefile target
 TEST_DEPS := client data_sink naughty_child wait_child
-# Tests: need to be compiled and run by test-% target
 
-TESTS ?= env empty hello_world malloc mmap file fs_perms getpid spawn sched pipe time \
-	truncate readdir mkdir open stat link symlink chmod chown tls pthread system_info rlimit \
-	server server_epoll unix_socket cout hostfs cpuid rdtsc device sleep exit_group posix_flock \
-	ioctl fcntl eventfd emulate_syscall access signal prctl rename procfs wait flock async_sfs \
-	spawn_attribute exec statfs random umask pgrp vfork mount sysinfo timerfd utimes shm epoll \
-	netlink brk disk
+# Tests: need to be compiled and run by test-% target
+TESTS ?= env empty hello_world malloc fs_perms getpid spawn sched pipe time \
+    readdir mkdir open stat link symlink tls pthread system_info rlimit \
+    server server_epoll unix_socket cout hostfs cpuid rdtsc device sleep exit_group posix_flock \
+    ioctl fcntl eventfd emulate_syscall signal prctl rename procfs wait flock async_sfs \
+    spawn_attribute exec statfs random pgrp vfork mount sysinfo timerfd shm epoll \
+    netlink brk disk
+
+# Legacy tests: Some cases still applied on legacy configuration due to functionality cause
+TESTS_LEGACY ?= mmap file truncate chmod chown access umask utimes
 
 # Benchmarks: need to be compiled and run by bench-% target
 BENCHES := spawn_and_exit_latency pipe_throughput unix_socket_throughput
@@ -33,8 +36,9 @@ BENCHES := spawn_and_exit_latency pipe_throughput unix_socket_throughput
 OCCLUM_BIN_PATH ?= $(BUILD_DIR)/bin
 
 # Top-level Makefile targets
-BUILD_TARGETS := $(TEST_DEPS) $(TESTS) $(BENCHES)
+BUILD_TARGETS := $(TEST_DEPS) $(TESTS) $(TESTS_LEGACY) $(BENCHES)
 TEST_TARGETS := $(TESTS:%=test-%)
+TEST_LEGACY_TARGETS := $(TESTS_LEGACY:%=test-%)
 BENCH_TARGETS := $(BENCHES:%=bench-%)
 .PHONY: all prebuild build postbuild test clean $(BUILD_TARGETS) $(TEST_TARGETS) $(BENCH_TARGETS) format format-check
 
@@ -67,6 +71,13 @@ prebuild:
 		$(OCCLUM_BIN_PATH)/occlum init
 	@cp Occlum.yaml $(BUILD_DIR)/test/
 
+prebuild-legacy:
+	@$(RM) -rf $(BUILD_DIR)/test
+	@mkdir -p $(BUILD_DIR)/test
+	@cd $(BUILD_DIR)/test && \
+		$(OCCLUM_BIN_PATH)/occlum init
+	@cp -f Occlum-legacy.yaml $(BUILD_DIR)/test/Occlum.yaml
+
 $(BUILD_TARGETS): %:
 	@$(ECHO) "$(CYAN)BUILD TEST => $@$(NO_COLOR)"
 	@$(MAKE) --no-print-directory -C $@
@@ -94,6 +105,11 @@ test-common:
 
 test-internal: build pretest $(TEST_TARGETS) posttest
 
+test-legacy:
+	@OCCLUM_TEST_GLIBC=1 $(MAKE) test-legacy-internal
+
+test-legacy-internal: prebuild-legacy $(BUILD_TARGETS) postbuild pretest $(TEST_LEGACY_TARGETS) posttest
+
 pretest:
 	@$(RM) $(PASS_LOG) $(FAIL_LOG)
 	@cd $(BUILD_DIR)/test && \
@@ -117,6 +133,21 @@ $(TEST_TARGETS): test-%: %
 			cd -; \
 		fi ; \
 	done
+
+$(TEST_LEGACY_TARGETS): test-%: %
+	@touch $(PASS_LOG) $(FAIL_LOG)
+	@$(ECHO) "$(CYAN)RUN TEST => $<$(NO_COLOR)"
+	@$(MAKE) --no-print-directory -C $< test ; \
+		if [ $$? -eq 0 ] ; then \
+			$(ECHO) "$(GREEN)PASS $(NO_COLOR)" ; \
+			$(ECHO) "$< PASS " >> $(PASS_LOG) ; \
+		else \
+			$(ECHO) "$(RED)FAILED$(NO_COLOR)" ; \
+			$(ECHO) "$< FAILED " >> $(FAIL_LOG) ; \
+			cd $(BUILD_DIR)/test && \
+			$(OCCLUM_BIN_PATH)/occlum start ; \
+			cd -; \
+		fi ; \
 
 posttest:
 	@cd $(BUILD_DIR)/test && \

--- a/test/Occlum-legacy.yaml
+++ b/test/Occlum-legacy.yaml
@@ -9,6 +9,7 @@ resource_limits:
   # Without EDMM support, increase the "init" field if memory insufficiency occurs. And the "max" field is ignored.
   kernel_space_heap_size:
     # Reserved and committed during the initialization stage. The more, the longer it takes to initialize.
+    # NOTE: Decrease this value when EDMM support is enabled.
     init: 512MB
     # Only committed when necessary. Only valid with EDMM support.
     max:  512MB
@@ -17,7 +18,8 @@ resource_limits:
   # Without EDMM support, increase the "init" field if memory insufficiency occurs. And the "max" field is ignored.
   user_space_size:
     # Reserved and committed during the initialization stage. The more, the longer it takes to initialize.
-    init: 256MB
+    # NOTE: Decrease this value when EDMM support is enabled.
+    init: 420MB
     # Only committed when necessary. Only valid with EDMM support.
     max:  64GB
 
@@ -26,7 +28,7 @@ process:
   # Default stack size for each process.
   default_stack_size: 4MB
   # Default heap size for each process.
-  default_heap_size: 32MB
+  default_heap_size: 8MB
 
 # Entry points
 # Specify all valid absolute <path> in `occlum run <path> <args>`.
@@ -44,6 +46,8 @@ env:
   # are specified in this config file, they are considered trusted.
   default:
     - OCCLUM=yes
+    - STABLE=yes
+    - OVERRIDE=N
   # The untrusted env vars that are captured by Occlum from the host environment
   # and passed to the "root" LibOS processes. These untrusted env vars can
   # override the trusted, default envs specified above.
@@ -55,7 +59,8 @@ env:
   #       untrusted:
   #         - OCCLUM
   untrusted:
-    - EXAMPLE
+    - TEST
+    - OVERRIDE
 
 # Enclave metadata
 # If not sure, just keep them no change
@@ -101,20 +106,8 @@ mount:
             MAC: ''
         # The read-write layer whose content is produced when running the LibOS
         - target: /
-          type: async_sfs
+          type: sefs
           source: ./run/mount/__ROOT
-          options:
-            # Total size that Async-SFS can manage. Must be specified.
-            async_sfs_total_size: 10GB
-            # Page cache size that Async-SFS can use. Must be specified.
-            # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
-            page_cache_size: 256MB
-            # The JinDisk under Async-SFS uses MRSIGNER to derive key by default, so the data can
-            # be shared between same enclave signer on the same machine.
-            # If you want more secure scheme, you can set the autokey_policy field
-            # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
-            # So the data can only be accessed by the enclave itself.
-            # autokey_policy: 1
   #
   # HostFS mount
   # It provides a channel to exchange files between Host FS and LibOS FS.
@@ -124,43 +117,6 @@ mount:
   # For example, below section mount the occlum_instance directory in the Host FS
   # to the path /host in the LibOS FS.
   # It is disabled in default. Uncomment it if you are very sure about it.
-  # - target: /host
-  #   type: hostfs
-  #   source: .
-  #
-  # SEFS mount
-  # - target: /sefs
-  #   type: sefs
-  #   source: ./run
-  #   options:
-  #     # The SEFS just uses MRSIGNER to derive key by default, so the data can
-  #     # be shared between same enclave signer on the same machine.
-  #     # If you want more secure scheme, you can set the autokey_policy field
-  #     # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
-  #     # So the data can only be accessed by the enclave itself.
-  #     autokey_policy: 1
-  #     # The SEFS internal cache size, increasing it will bring better file I/O 
-  #     # performance but also consume Occlum's kernel heap size.
-  #     sefs_cache_size: 192KB
-#
-# Untrusted Unix domain socket
-# Besides the common Unix domain socket support that both ends are created in the same
-# Occlum instance, the Untrusted Unix domain socket can support cross-world connection by
-# mapping a libos socket address with the host socket address. In this way, a Unix domain
-# socket created in Occlum can communicate with a Unix domain socket in the host OS or in
-# another Occlum instance.
-# Uncomment and customize below if you are very sure about it.
-#
-# untrusted_unix_socks:
-# The libos path and the host path correspond to the same host sock file.
-# The host side should use the host path and libos side should use the libos path.
-#
-# Specify socket file in absolute path
-  # - host: /tmp/occlum/test.sock
-  #   libos: /root/test.sock
-# Or any files in the path
-  # - host: /tmp/root/
-  #   libos: /root/
-# Or the host path can be a relative path and is relative to the current Occlum instance dir.
-  # - host: ../test.sock
-  #   libos: /tmp/test.sock
+  - target: /host
+    type: hostfs
+    source: .

--- a/test/Occlum.yaml
+++ b/test/Occlum.yaml
@@ -10,9 +10,9 @@ resource_limits:
   kernel_space_heap_size:
     # Reserved and committed during the initialization stage. The more, the longer it takes to initialize.
     # NOTE: Decrease this value when EDMM support is enabled.
-    init: 512MB
+    init: 1024MB
     # Only committed when necessary. Only valid with EDMM support.
-    max:  512MB
+    max:  1024MB
   # The total size of enclave memory available to the user applications running in LibOS.
   # With EDMM support, choose "init" size based on the expected initialization time. And increase the "max" field if memory insufficiency occurs.
   # Without EDMM support, increase the "init" field if memory insufficiency occurs. And the "max" field is ignored.
@@ -106,8 +106,14 @@ mount:
             MAC: ''
         # The read-write layer whose content is produced when running the LibOS
         - target: /
-          type: sefs
+          type: async_sfs
           source: ./run/mount/__ROOT
+          options:
+            # Total size that Async-SFS can manage. Must be specified.
+            async_sfs_total_size: 10GB
+            # Page cache size that Async-SFS can use. Must be specified.
+            # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
+            page_cache_size: 256MB
   #
   # HostFS mount
   # It provides a channel to exchange files between Host FS and LibOS FS.
@@ -120,11 +126,3 @@ mount:
   - target: /host
     type: hostfs
     source: .
-  #
-  # Async FS mount
-  - target: /sfs
-    type: async_sfs
-    source: ./run/async_sfs_image
-    options:
-      async_sfs_total_size: 4GB
-      page_cache_size: 256MB

--- a/test/mount/main.c
+++ b/test/mount/main.c
@@ -91,7 +91,8 @@ static int __test_mount_unionfs(const char *mnt_dir) {
     }
 
     if (mount("unionfs", mnt_dir, "unionfs", 0,
-              "lowerdir=./mnt_test/mnt_unionfs/lower,upperdir=./mnt_test/mnt_unionfs/upper") < 0) {
+              "lowerdir=./mnt_test/mnt_unionfs/lower,lowerfs=sefs,upperdir=./mnt_test/mnt_unionfs/upper,upperfs=async_sfs,sfssize=5GB,cachesize=128MB")
+            < 0) {
         THROW_ERROR("failed to mount unionfs");
     }
 

--- a/tools/occlum
+++ b/tools/occlum
@@ -67,6 +67,7 @@ Usage:
 
     occlum init
         Initialize a directory as the Occlum instance.
+        To use SEFS as Occlum's default root file system, give the [--use-sefs] flag.
 
     occlum build [--sign-key <key_path>] [--sign-tool <tool_path>] [--image-key <key_path>] [-f/--force]
         Build and sign an Occlum SGX enclave (.so) and generate its associated secure
@@ -204,6 +205,7 @@ cmd_init() {
     mkdir -p image/host
     mkdir -p image/tmp
     mkdir -p image/sfs
+    mkdir -p image/sefs
     mkdir -p image/dev
     mkdir -p image/proc
     mkdir -p image/etc
@@ -273,6 +275,9 @@ cmd_init() {
     cp "$occlum_dir"/build/bin/init initfs/bin/
 
     cp "$occlum_dir"/etc/template/Occlum.yaml "$instance_dir"/
+    if [ "$1" = "--use-sefs" ]; then
+       cp -f "$occlum_dir"/etc/template/Occlum-legacy.yaml "$instance_dir"/Occlum.yaml 
+    fi
     chmod 644 "$instance_dir"/Occlum.yaml
 
     echo "$instance_dir initialized as an Occlum instance"
@@ -677,7 +682,7 @@ case "$cmd" in
         cmd_new "${@:2:1}"
         ;;
     init)
-        cmd_init
+        cmd_init "${@:2:1}"
         ;;
     build)
         cmd_build "${@:2}"


### PR DESCRIPTION
This PR includes:

- AsyncSFS+PageCache+JinDisk are Occlum's default storage backend now. The rootfs(unionfs) is initialized as RO layer: SEFS and RW layer: AsyncSFS+JinDisk. The initfs remains same configuration (RO-SEFS and RW-SEFS) in initialize stage.
- The default `resource_limits.kernel_space_heap_size` is increased since PageCache(256MB by default) and JinDisk(8MB per GB data + 64MB fixedly) would consume more.
- The legacy configuration(SEFS) is preserved since AsyncSFS has some unsupported/incomplete features compared to SEFS, tracked in https://github.com/occlum/occlum/issues/1281
- `occlum mount` is temporarily unusable until jindisk-cli is delivered to replace sefs-cli. `occlum mount` could also be replaced by building a [busybox](https://github.com/mirror/busybox) inside occlum and do `occlum run /bin/busybox [cmd]` to check dirs and file contents.