### PR TITLE
[jindisk] Support get the root key given key policy

### DIFF
--- a/etc/template/Occlum.yaml
+++ b/etc/template/Occlum.yaml
@@ -104,10 +104,10 @@ mount:
           type: sefs
           source: ./run/mount/__ROOT
           # options:
-          # The SEFS just uses MRSIGNER to drived key by default, so the data can
+          # The SEFS just uses MRSIGNER to derive key by default, so the data can
           # be shared between same enclave signer on the same machine.
           # If you want more secure scheme, you can set the autokey_policy field
-          # to 1 to enforcing the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
+          # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
           # So the data can only be accessed by the enclave itself.
           #  autokey_policy: 1
           # The SEFS internal cache size, increasing it will bring better file I/O 
@@ -136,6 +136,12 @@ mount:
   #     # Page cache size that Async-SFS can use. Must be specified.
   #     # When the `page_cache_size` is given, the `kernel_space_heap_size` must be increased equally.
   #     page_cache_size: 256MB
+  #     # The JinDisk under Async-SFS uses MRSIGNER to derive key by default, so the data can
+  #     # be shared between same enclave signer on the same machine.
+  #     # If you want more secure scheme, you can set the autokey_policy field
+  #     # to 1 to enforce the key is derived by MRSIGNER|MRENCLAVE|ISVFAMILYID.
+  #     # So the data can only be accessed by the enclave itself.
+  #     autokey_policy: 1
 #
 # Untrusted Unix domain socket
 # Besides the common Unix domain socket support that both ends are created in the same

--- a/src/libos/src/fs/mod.rs
+++ b/src/libos/src/fs/mod.rs
@@ -38,6 +38,7 @@ pub use self::locks::{
     RangeLockType, OFFSET_MAX,
 };
 pub use self::rootfs::rootfs;
+pub use self::sefs::KeyPolicy;
 pub use self::stdio::{HostStdioFds, StdinFile, StdoutFile};
 pub use self::syscalls::*;
 

--- a/src/libos/src/fs/sefs/mod.rs
+++ b/src/libos/src/fs/sefs/mod.rs
@@ -1,6 +1,6 @@
 use super::{sgx_aes_gcm_128bit_tag_t, sgx_key_128bit_t};
 
-pub use self::sgx_storage::SgxStorage;
+pub use self::sgx_storage::{KeyPolicy, SgxStorage};
 pub use self::sgx_uuid_provider::SgxUuidProvider;
 
 mod sgx_storage;

--- a/src/libos/src/fs/sefs/sgx_storage.rs
+++ b/src/libos/src/fs/sefs/sgx_storage.rs
@@ -242,7 +242,7 @@ impl EncryptMode {
 }
 
 bitflags! {
-    struct KeyPolicy: u16 {
+    pub struct KeyPolicy: u16 {
         const KEYPOLICY_MRENCLAVE = 0x0001;
         const KEYPOLICY_MRSIGNER = 0x0002;
         const KEYPOLICY_NOISVPRODID = 0x0004;

--- a/src/libos/src/util/sgx/mod.rs
+++ b/src/libos/src/util/sgx/mod.rs
@@ -21,7 +21,7 @@ pub use self::dcap::{
     QuoteGenerator as SgxDCAPQuoteGenerator, QuoteVerifier as SgxDCAPQuoteVerifier,
 };
 pub use self::epid::AttestationAgent as SgxEPIDAttestationAgent;
-pub use self::sgx_key::get_key;
+pub use self::sgx_key::{get_autokey_with_policy, get_key};
 pub use self::sgx_report::{create_report, get_self_target, verify_report};
 
 pub fn allow_debug() -> bool {

--- a/src/libos/src/util/sgx/sgx_key.rs
+++ b/src/libos/src/util/sgx/sgx_key.rs
@@ -1,6 +1,12 @@
 use super::*;
+use crate::fs::KeyPolicy;
+use crate::misc::get_random;
 
+use std::io::{Read, Write};
+use std::mem::{size_of, transmute};
+use std::path::PathBuf;
 use std::ptr;
+use std::untrusted::{fs::File, path::PathEx};
 
 pub fn get_key(key_request: &sgx_key_request_t) -> Result<sgx_key_128bit_t> {
     let mut key = sgx_key_128bit_t::default();
@@ -12,5 +18,113 @@ pub fn get_key(key_request: &sgx_key_request_t) -> Result<sgx_key_128bit_t> {
             error!("sgx_get_key return {:?}", sgx_status);
             return_errno!(EINVAL, "unexpected SGX error")
         }
+    }
+}
+
+pub fn get_autokey_with_policy(
+    autokey_policy: &Option<u32>,
+    path: &PathBuf,
+) -> Result<sgx_key_128bit_t> {
+    let mut key_request = sgx_key_request_t::default();
+
+    key_request.key_name = SGX_KEYSELECT_SEAL;
+    key_request.key_policy = {
+        let key_policy = autokey_policy
+            .and_then(|policy| KeyPolicy::from_u32(policy))
+            .map_or(SGX_KEYPOLICY_MRSIGNER, |policy| policy.bits());
+        if (key_policy
+            & !(SGX_KEYPOLICY_MRENCLAVE
+                | SGX_KEYPOLICY_MRSIGNER
+                | SGX_KEYPOLICY_CONFIGID
+                | SGX_KEYPOLICY_ISVFAMILYID
+                | SGX_KEYPOLICY_ISVEXTPRODID
+                | SGX_KEYPOLICY_NOISVPRODID)
+            != 0)
+            || (key_policy & (SGX_KEYPOLICY_MRENCLAVE | SGX_KEYPOLICY_MRSIGNER)) == 0
+        {
+            return_errno!(EINVAL, "autokey policy is invalid")
+        }
+        key_policy
+    };
+
+    let key_metadata = {
+        let metadata_path = {
+            let mut metadata_path = path.clone();
+            if !metadata_path.is_dir() {
+                metadata_path = metadata_path.parent().unwrap().to_path_buf();
+            }
+            metadata_path.push(KEY_METADATA_FILE_NAME);
+            metadata_path
+        };
+        let fetch_res = if metadata_path.exists() {
+            KeyMetadata::fetch_from(&metadata_path)
+        } else {
+            Err(errno!(ENOENT))
+        };
+        fetch_res.unwrap_or_else(|_| {
+            let key_metadata = KeyMetadata::default();
+            let _ = key_metadata.persist_to(&metadata_path);
+            key_metadata
+        })
+    };
+    key_request.key_id = key_metadata.key_id;
+    key_request.cpu_svn = key_metadata.cpu_svn;
+    key_request.isv_svn = key_metadata.isv_svn;
+
+    key_request.attribute_mask.flags = TSEAL_DEFAULT_FLAGSMASK;
+    key_request.attribute_mask.xfrm = 0x0;
+    key_request.misc_mask = TSEAL_DEFAULT_MISCMASK;
+
+    get_key(&key_request)
+}
+
+const KEY_METADATA_FILE_NAME: &str = "metadata";
+const KEY_METADATA_SIZE: usize = size_of::<KeyMetadata>();
+
+#[repr(C)]
+struct KeyMetadata {
+    pub key_id: sgx_key_id_t,
+    pub cpu_svn: sgx_cpu_svn_t,
+    pub isv_svn: sgx_isv_svn_t,
+}
+
+impl Default for KeyMetadata {
+    fn default() -> Self {
+        let key_id = {
+            let mut key_id = sgx_key_id_t::default();
+            let _ = get_random(&mut key_id.id);
+            key_id
+        };
+        let report = sgx_tse::rsgx_self_report();
+        Self {
+            key_id,
+            cpu_svn: report.body.cpu_svn,
+            isv_svn: report.body.isv_svn,
+        }
+    }
+}
+
+impl KeyMetadata {
+    fn fetch_from(metadata_path: &PathBuf) -> Result<Self> {
+        debug_assert!(metadata_path.ends_with(KEY_METADATA_FILE_NAME));
+        let mut metadata_file = File::open(metadata_path)?;
+        let mut metadata_buf = [0u8; KEY_METADATA_SIZE];
+        metadata_file.read(&mut metadata_buf)?;
+        Ok(Self::from_bytes(metadata_buf))
+    }
+
+    fn persist_to(&self, metadata_path: &PathBuf) -> Result<()> {
+        debug_assert!(metadata_path.ends_with(KEY_METADATA_FILE_NAME));
+        let mut metadata_file = File::create(metadata_path)?;
+        metadata_file.write(self.to_bytes())?;
+        Ok(())
+    }
+
+    fn to_bytes(&self) -> &[u8; KEY_METADATA_SIZE] {
+        unsafe { transmute::<&Self, &[u8; KEY_METADATA_SIZE]>(self) }
+    }
+
+    fn from_bytes(bytes: [u8; KEY_METADATA_SIZE]) -> Self {
+        unsafe { transmute::<[u8; KEY_METADATA_SIZE], Self>(bytes) }
     }
 }


### PR DESCRIPTION
The root key of JinDisk can now be obtained from 1. user-given key 2. derive with user-given key policy 3. derive with default key policy - `SGX_KEYPOLICY_MRSIGNER` (which behavior is similar to SGX-PFS's autokey generation: [pos](https://github.com/occlum/linux-sgx/blob/sgx_2.19_for_ngo/sdk/protected_fs/sgx_tprotected_fs/file_crypto.cpp#L207))

When using derived key, some key metadata (key_id, cpu_svn, isv_svn) are persisted to an untrusted file (similar to PFS's metadata node). The file stands next to jindisk's image path.