### PR TITLE
[jindisk] Protect RIT with symmetric key cipher

### DIFF
--- a/src/libos/crates/jindisk/src/checkpoint/rit.rs
+++ b/src/libos/crates/jindisk/src/checkpoint/rit.rs
@@ -11,10 +11,10 @@ pub struct RIT {
 }
 
 impl RIT {
-    pub fn new(region_addr: Hba, data_region_addr: Hba, disk: DiskView) -> Self {
+    pub fn new(region_addr: Hba, data_region_addr: Hba, disk: DiskView, key: &Key) -> Self {
         Self {
             data_region_addr,
-            disk_array: DiskArray::new(region_addr, disk.clone()),
+            disk_array: DiskArray::new(region_addr, disk.clone(), key),
         }
     }
 
@@ -63,9 +63,14 @@ impl RIT {
         disk: &DiskView,
         region_addr: Hba,
         data_region_addr: Hba,
-        _root_key: &Key,
+        root_key: &Key,
     ) -> Result<Self> {
-        Ok(Self::new(region_addr, data_region_addr, disk.clone()))
+        Ok(Self::new(
+            region_addr,
+            data_region_addr,
+            disk.clone(),
+            root_key,
+        ))
     }
 }
 
@@ -87,7 +92,8 @@ mod tests {
         async_rt::task::block_on(async move {
             let disk = Arc::new(MemDisk::new(1024usize).unwrap());
             let disk = DiskView::new_unchecked(disk);
-            let mut rit = RIT::new(Hba::new(0), Hba::new(0), disk.clone());
+            let key = DefaultCryptor::gen_random_key();
+            let mut rit = RIT::new(Hba::new(0), Hba::new(0), disk.clone(), &key);
 
             let kv1 = (Hba::new(1), Lba::new(2));
             let kv2 = (Hba::new(1025), Lba::new(5));

--- a/src/libos/crates/jindisk/src/jindisk.rs
+++ b/src/libos/crates/jindisk/src/jindisk.rs
@@ -61,7 +61,11 @@ impl JinDisk {
         let superblock = SuperBlock::init(disk.total_blocks());
 
         let checkpoint_disk_view = Self::checkpoint_disk_view(&superblock, &disk);
-        let checkpoint = Arc::new(Checkpoint::new(&superblock, checkpoint_disk_view));
+        let checkpoint = Arc::new(Checkpoint::new(
+            &superblock,
+            checkpoint_disk_view,
+            &root_key,
+        ));
 
         let index_disk_view = Self::index_disk_view(&superblock, &disk);
         let lsm_tree = Arc::new(LsmTree::new(index_disk_view, checkpoint.clone()));

--- a/src/libos/crates/jindisk/src/util/cryption.rs
+++ b/src/libos/crates/jindisk/src/util/cryption.rs
@@ -2,9 +2,13 @@
 use crate::prelude::*;
 use cfg_if::cfg_if;
 #[cfg(not(feature = "sgx"))]
-use openssl::symm::{decrypt_aead, encrypt_aead, Cipher};
+use openssl::rand::rand_bytes;
+#[cfg(not(feature = "sgx"))]
+use openssl::symm::{decrypt, decrypt_aead, encrypt, encrypt_aead, Cipher};
 #[cfg(feature = "sgx")]
 use sgx_rand::{thread_rng, Rng};
+#[cfg(feature = "sgx")]
+use sgx_tcrypto::{rsgx_aes_ctr_decrypt, rsgx_aes_ctr_encrypt};
 #[cfg(feature = "sgx")]
 use sgx_tcrypto::{rsgx_rijndael128GCM_decrypt, rsgx_rijndael128GCM_encrypt};
 #[cfg(feature = "sgx")]
@@ -37,6 +41,12 @@ pub trait Cryption {
         key: &Key,
         meta: &CipherMeta,
     ) -> Result<()>;
+
+    /// Encrypt a block using symmetric key cipher(AES128 CTR mode)
+    fn symm_encrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]>;
+
+    /// Decrypt a block using symmetric key cipher(AES128 CTR mode)
+    fn symm_decrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -114,6 +124,14 @@ impl Cryption for DefaultCryptor {
     ) -> Result<()> {
         Self::dec_any(ciphertext, plaintext, key, meta)
     }
+
+    fn symm_encrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        Self::symm_enc_block(data, key)
+    }
+
+    fn symm_decrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        Self::symm_dec_block(data, key)
+    }
 }
 
 // TODO: Support symmetric encryption for blocks
@@ -121,8 +139,13 @@ impl DefaultCryptor {
     #[allow(unused_mut)]
     pub fn gen_random_key() -> Key {
         let mut rand_key = [5u8; AUTH_ENC_KEY_SIZE];
-        #[cfg(feature = "sgx")]
-        thread_rng().fill_bytes(&mut rand_key);
+        cfg_if! {
+            if #[cfg(feature = "sgx")] {
+                thread_rng().fill_bytes(&mut rand_key);
+            } else {
+                rand_bytes(&mut rand_key);
+            }
+        }
         rand_key
     }
 
@@ -264,6 +287,62 @@ impl DefaultCryptor {
         }
         Ok(())
     }
+
+    fn symm_enc_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        let mut output = [0u8; BLOCK_SIZE];
+        let mut ctr = [2u8; 16];
+
+        cfg_if! {
+            // AES128-CTR
+            if #[cfg(feature = "sgx")] {
+                let ctr_inc_bits = 128u32;
+                match rsgx_aes_ctr_encrypt(key, data, &mut ctr, ctr_inc_bits, &mut output) {
+                    Ok(_) => (),
+                    Err(_) => {
+                        return_errno!(EINVAL, "SGX: rsgx_aes_ctr_encrypt error");
+                    }
+                }
+            } else {
+                match encrypt(Cipher::aes_128_ctr(), key, Some(&ctr), data) {
+                    Ok(ciphertext) => {
+                        output.copy_from_slice(&ciphertext);
+                    },
+                    Err(_) => {
+                        return_errno!(EINVAL, "OPENSSL: aes_128_ctr encryption error");
+                    }
+                }
+            }
+        }
+        Ok(output)
+    }
+
+    fn symm_dec_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        let mut output = [0u8; BLOCK_SIZE];
+        let mut ctr = [2u8; 16];
+
+        cfg_if! {
+            // AES128-CTR
+            if #[cfg(feature = "sgx")] {
+                let ctr_inc_bits = 128u32;
+                match rsgx_aes_ctr_decrypt(key, data, &mut ctr, ctr_inc_bits, &mut output) {
+                    Ok(_) => (),
+                    Err(_) => {
+                        return_errno!(EINVAL, "SGX: rsgx_aes_ctr_decrypt error");
+                    }
+                }
+            } else {
+                match decrypt(Cipher::aes_128_ctr(), key, Some(&ctr), data) {
+                    Ok(ciphertext) => {
+                        output.copy_from_slice(&ciphertext);
+                    },
+                    Err(_) => {
+                        return_errno!(EINVAL, "OPENSSL: aes_128_ctr decryption error");
+                    }
+                }
+            }
+        }
+        Ok(output)
+    }
 }
 
 impl Encoder for Mac {
@@ -301,5 +380,15 @@ mod tests {
         let mut decrypted = [0u8; SIZE];
         let _ = DefaultCryptor::decrypt_arbitrary(&cipher, &mut decrypted, &key, &cipher_meta);
         assert_eq!(plain, decrypted);
+    }
+
+    #[test]
+    fn test_symm_enc_dec() {
+        let key = DefaultCryptor::gen_random_key();
+        let plaintext = [0u8; BLOCK_SIZE];
+        let ciphertext = DefaultCryptor::symm_encrypt_block(&plaintext, &key).unwrap();
+        assert_ne!(plaintext, ciphertext);
+        let decrypted = DefaultCryptor::symm_decrypt_block(&ciphertext, &key).unwrap();
+        assert_eq!(plaintext, decrypted);
     }
 }


### PR DESCRIPTION
This PR contains:
- Add symmetric key cipher (AES128 CTR mode) api
- Add encryption(symmetric) for DiskArray blocks

Only RIT implementation uses the DiskArray at the moment.