### PR TITLE
[net] Support send/receive control message in unix socket

### DIFF
--- a/src/libos/src/net/socket/mod.rs
+++ b/src/libos/src/net/socket/mod.rs
@@ -14,7 +14,7 @@ pub use self::address_family::AddressFamily;
 pub use self::flags::{FileFlags, MsgHdrFlags, RecvFlags, SendFlags};
 pub use self::host::{HostSocket, HostSocketType};
 pub use self::iovs::{Iovs, IovsMut, SliceAsLibcIovec};
-pub use self::msg::{mmsghdr, msghdr, msghdr_mut, MsgHdr, MsgHdrMut};
+pub use self::msg::{mmsghdr, msghdr, msghdr_mut, CMessages, CmsgData, MsgHdr, MsgHdrMut};
 pub use self::shutdown::HowToShut;
 pub use self::socket_address::SockAddr;
 pub use self::socket_type::SocketType;

--- a/src/libos/src/net/socket/msg.rs
+++ b/src/libos/src/net/socket/msg.rs
@@ -219,6 +219,119 @@ impl<'a> MsgHdrMut<'a> {
     }
 }
 
+/// This struct is used to iterate through the control messages.
+///
+/// `cmsghdr` is a C struct for ancillary data object information of a unix socket.
+pub struct CMessages<'a> {
+    buffer: &'a [u8],
+    current: Option<&'a libc::cmsghdr>,
+}
+
+impl<'a> Iterator for CMessages<'a> {
+    type Item = CmsgData<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let cmsg = unsafe {
+            let mut msg: libc::msghdr = core::mem::zeroed();
+            msg.msg_control = self.buffer.as_ptr() as *mut _;
+            msg.msg_controllen = self.buffer.len() as _;
+
+            let cmsg = if let Some(current) = self.current {
+                libc::CMSG_NXTHDR(&msg, current)
+            } else {
+                libc::CMSG_FIRSTHDR(&msg)
+            };
+            cmsg.as_ref()?
+        };
+
+        self.current = Some(cmsg);
+        CmsgData::try_from_cmsghdr(cmsg)
+    }
+}
+
+impl<'a> CMessages<'a> {
+    pub fn from_bytes(msg_control: &'a mut [u8]) -> Self {
+        Self {
+            buffer: msg_control,
+            current: None,
+        }
+    }
+}
+
+/// Control message data of variable type. The data resides next to `cmsghdr`.
+pub enum CmsgData<'a> {
+    ScmRights(ScmRights<'a>),
+    ScmCredentials,
+}
+
+impl<'a> CmsgData<'a> {
+    /// Create an `CmsgData::ScmRights` variant.
+    ///
+    /// # Safety
+    ///
+    /// `data` must contain a valid control message and the control message must be type of
+    /// `SOL_SOCKET` and level of `SCM_RIGHTS`.
+    unsafe fn as_rights(data: &'a mut [u8]) -> Self {
+        let scm_rights = ScmRights { data };
+        CmsgData::ScmRights(scm_rights)
+    }
+
+    /// Create an `CmsgData::ScmCredentials` variant.
+    ///
+    /// # Safety
+    ///
+    /// `data` must contain a valid control message and the control message must be type of
+    /// `SOL_SOCKET` and level of `SCM_CREDENTIALS`.
+    unsafe fn as_credentials(_data: &'a [u8]) -> Self {
+        CmsgData::ScmCredentials
+    }
+
+    fn try_from_cmsghdr(cmsg: &'a libc::cmsghdr) -> Option<Self> {
+        unsafe {
+            let cmsg_len_zero = libc::CMSG_LEN(0) as usize;
+            let data_len = (*cmsg).cmsg_len as usize - cmsg_len_zero;
+            let data = libc::CMSG_DATA(cmsg);
+            let data = core::slice::from_raw_parts_mut(data, data_len);
+
+            match (*cmsg).cmsg_level {
+                libc::SOL_SOCKET => match (*cmsg).cmsg_type {
+                    libc::SCM_RIGHTS => Some(CmsgData::as_rights(data)),
+                    libc::SCM_CREDENTIALS => Some(CmsgData::as_credentials(data)),
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+    }
+}
+
+/// The data unit of this control message is file descriptor(s).
+///
+/// The level is equal to `SOL_SOCKET` and the type is equal to `SCM_RIGHTS`.
+pub struct ScmRights<'a> {
+    data: &'a mut [u8],
+}
+
+impl<'a> ScmRights<'a> {
+    /// Iterate and reassign each fd in data buffer, given a reassignment function.
+    pub fn iter_and_reassign_fds<F>(&mut self, reassign_fd_fn: F)
+    where
+        F: Fn(FileDesc) -> FileDesc,
+    {
+        for fd_bytes in self.data.chunks_exact_mut(core::mem::size_of::<FileDesc>()) {
+            let old_fd = FileDesc::from_ne_bytes(fd_bytes.try_into().unwrap());
+            let reassigned_fd = reassign_fd_fn(old_fd);
+            fd_bytes.copy_from_slice(&reassigned_fd.to_ne_bytes());
+        }
+    }
+
+    pub fn iter_fds(&self) -> impl Iterator<Item = FileDesc> + '_ {
+        self.data
+            .chunks_exact(core::mem::size_of::<FileDesc>())
+            .map(|fd_bytes| FileDesc::from_ne_bytes(fd_bytes.try_into().unwrap()))
+    }
+}
+
 unsafe fn new_optional_slice<'a, T>(slice_ptr: *const T, slice_size: usize) -> Option<&'a [T]> {
     if !slice_ptr.is_null() {
         let slice = core::slice::from_raw_parts::<T>(slice_ptr, slice_size);


### PR DESCRIPTION
This PR adds support for unix stream socket to send/receive msg_control, see [cmsg](https://man7.org/linux/man-pages/man3/cmsg.3.html). The control messages are mainly used for send/receive file descriptors.
Having this feature, `sendmsg()`/`recvmsg()` of unix socket can parse, extract, reassign fd in `msg_control`.