### PR TITLE
[poll] Fix panic for non-opened fds

### DIFF
--- a/src/libos/src/net/io_multiplexing/poll_new/mod.rs
+++ b/src/libos/src/net/io_multiplexing/poll_new/mod.rs
@@ -35,6 +35,7 @@ pub fn do_poll_new(poll_fds: &[PollFd], mut timeout: Option<&mut Duration>) -> R
             if file.is_none() {
                 poll_fd.revents.set(IoEvents::NVAL);
                 invalid_fd_count += 1;
+                return None;
             }
 
             Some((file.unwrap(), poll_fd.events))


### PR DESCRIPTION
Fix a bug recently introduced by the support of negative poll_fd.