### PR TITLE
[jindisk] Improve block cryption, reclaim and discard

### DIFF
--- a/src/libos/crates/jindisk/README.md
+++ b/src/libos/crates/jindisk/README.md
@@ -16,7 +16,7 @@ JinDisk targets a typical setting of TEE usage, where applications are ported in
 
 ![The threat model of JinDisk.](https://user-images.githubusercontent.com/22837133/202613207-907cd9ed-338b-47a4-a558-b3713e531faf.png)
 
-As shown in the image above, the TEE runtime is integrated with JinDisk, which serves as a trusted logical block device that supports four standard block I/O commands including `read()`, `write()`, `flush()`, and `trim()`. From the perspective of JinDisk's users (e.g., file systems), all data written to or read from JinDisk is in plaintext. To serve these I/O requests securely, JinDisk takes some extra security measures, including but not limited to encrypting/decrypting the data transferred to/from the host block device properly.
+As shown in the image above, the TEE runtime is integrated with JinDisk, which serves as a trusted logical block device that supports four standard block I/O commands including `read()`, `write()`, `flush()`, and `discard()`. From the perspective of JinDisk's users (e.g., file systems), all data written to or read from JinDisk is in plaintext. To serve these I/O requests securely, JinDisk takes some extra security measures, including but not limited to encrypting/decrypting the data transferred to/from the host block device properly.
 
 To distinguish between the addresses on the trusted logical block device (i.e., JinDisk) and on the untrusted host block device, we term the former as _logical block addresses (LBAs)_ and the latter _host block addresses (HBAs)_.
 

--- a/src/libos/crates/jindisk/src/checkpoint/rit.rs
+++ b/src/libos/crates/jindisk/src/checkpoint/rit.rs
@@ -11,10 +11,10 @@ pub struct RIT {
 }
 
 impl RIT {
-    pub fn new(region_addr: Hba, data_region_addr: Hba, disk: DiskView) -> Self {
+    pub fn new(region_addr: Hba, data_region_addr: Hba, disk: DiskView, key: &Key) -> Self {
         Self {
             data_region_addr,
-            disk_array: DiskArray::new(region_addr, disk.clone()),
+            disk_array: DiskArray::new(region_addr, disk.clone(), key),
         }
     }
 
@@ -63,9 +63,14 @@ impl RIT {
         disk: &DiskView,
         region_addr: Hba,
         data_region_addr: Hba,
-        _root_key: &Key,
+        root_key: &Key,
     ) -> Result<Self> {
-        Ok(Self::new(region_addr, data_region_addr, disk.clone()))
+        Ok(Self::new(
+            region_addr,
+            data_region_addr,
+            disk.clone(),
+            root_key,
+        ))
     }
 }
 
@@ -87,7 +92,8 @@ mod tests {
         async_rt::task::block_on(async move {
             let disk = Arc::new(MemDisk::new(1024usize).unwrap());
             let disk = DiskView::new_unchecked(disk);
-            let mut rit = RIT::new(Hba::new(0), Hba::new(0), disk.clone());
+            let key = DefaultCryptor::gen_random_key();
+            let mut rit = RIT::new(Hba::new(0), Hba::new(0), disk.clone(), &key);
 
             let kv1 = (Hba::new(1), Lba::new(2));
             let kv2 = (Hba::new(1025), Lba::new(5));

--- a/src/libos/crates/jindisk/src/config.rs
+++ b/src/libos/crates/jindisk/src/config.rs
@@ -63,7 +63,7 @@ pub const DATA_SIZE_PER_BIT: usize = MAX_RECORD_NUM_PER_BIT * BLOCK_SIZE;
 pub const MAX_LEVEL0_BIT_NUM: usize = 1;
 
 /// ## Record
-// Negative hba/lba (Used for delayed reclamation and trim)
+// Negative hba/lba (Used for delayed reclamation and block discard)
 pub const NEGATIVE_HBA: Hba = Hba::new(RawBid::MAX as _);
 pub const NEGATIVE_LBA: Lba = Lba::new(RawBid::MAX as _);
 

--- a/src/libos/crates/jindisk/src/data/cache.rs
+++ b/src/libos/crates/jindisk/src/data/cache.rs
@@ -459,7 +459,7 @@ impl SegmentBuffer {
             .map(|(idx, (&lba, data_block))| {
                 (
                     lba,
-                    DefaultCryptor::encrypt_block(
+                    DefaultCryptor::encrypt_block_aead(
                         data_block.as_slice(),
                         &self.checkpoint.key_table().fetch_key(allocated_blocks[idx]),
                     ),

--- a/src/libos/crates/jindisk/src/data/cleaning.rs
+++ b/src/libos/crates/jindisk/src/data/cleaning.rs
@@ -152,7 +152,7 @@ impl Inner {
             // Read and decrypt from disk
             let mut rbuf = [0u8; BLOCK_SIZE];
             self.disk.read(record.hba(), &mut rbuf).await?;
-            let decrypted = DefaultCryptor::decrypt_block(
+            let decrypted = DefaultCryptor::decrypt_block_aead(
                 &rbuf,
                 &self.checkpoint.key_table().fetch_key(record.hba()),
                 record.cipher_meta(),

--- a/src/libos/crates/jindisk/src/index/bit/builder.rs
+++ b/src/libos/crates/jindisk/src/index/bit/builder.rs
@@ -87,7 +87,7 @@ impl BitBuilder {
         let mut encoded_root_block = [0u8; ROOT_BLOCK_SIZE];
         root_block.encode(&mut encoded_root_block).unwrap();
         let mut cipher_root_block = [0u8; ROOT_BLOCK_SIZE];
-        let cipher_meta = DefaultCryptor::encrypt_arbitrary(
+        let cipher_meta = DefaultCryptor::encrypt_arbitrary_aead(
             &encoded_root_block,
             &mut cipher_root_block,
             &self.key,
@@ -136,7 +136,7 @@ impl BitBuilder {
             let mut encoded_internal_block = [0u8; INTERNAL_BLOCK_SIZE];
             internal_block.encode(&mut encoded_internal_block).unwrap();
             let mut cipher_internal_block = [0u8; INTERNAL_BLOCK_SIZE];
-            let cipher_meta = DefaultCryptor::encrypt_arbitrary(
+            let cipher_meta = DefaultCryptor::encrypt_arbitrary_aead(
                 &encoded_internal_block,
                 &mut cipher_internal_block,
                 &self.key,
@@ -183,7 +183,8 @@ impl BitBuilder {
             // Encode and encrypt leaf node
             let mut encoded_leaf_block = [0u8; LEAF_BLOCK_SIZE];
             leaf_block.encode(&mut encoded_leaf_block).unwrap();
-            let cipher_leaf_block = DefaultCryptor::encrypt_block(&encoded_leaf_block, &self.key);
+            let cipher_leaf_block =
+                DefaultCryptor::encrypt_block_aead(&encoded_leaf_block, &self.key);
 
             let leaf_record = LeafRecord::new(
                 lba_range,

--- a/src/libos/crates/jindisk/src/index/bit/mem_bit.rs
+++ b/src/libos/crates/jindisk/src/index/bit/mem_bit.rs
@@ -301,7 +301,7 @@ impl Bit {
 
         // Decrypt and decode
         let mut decrypted = [0u8; ROOT_BLOCK_SIZE];
-        DefaultCryptor::decrypt_arbitrary(
+        DefaultCryptor::decrypt_arbitrary_aead(
             &rbuf[0..ROOT_BLOCK_SIZE],
             &mut decrypted,
             self.key(),
@@ -324,7 +324,7 @@ impl Bit {
 
         // Decrypt and decode
         let mut decrypted = [0u8; INTERNAL_BLOCK_SIZE];
-        DefaultCryptor::decrypt_arbitrary(
+        DefaultCryptor::decrypt_arbitrary_aead(
             &rbuf[0..INTERNAL_BLOCK_SIZE],
             &mut decrypted,
             self.key(),
@@ -347,7 +347,7 @@ impl Bit {
 
         // Decrypt and decode
         let decrypted =
-            DefaultCryptor::decrypt_block(&rbuf, self.key(), leaf_record.cipher_meta())?;
+            DefaultCryptor::decrypt_block_aead(&rbuf, self.key(), leaf_record.cipher_meta())?;
 
         LeafBlock::decode(&decrypted)
     }

--- a/src/libos/crates/jindisk/src/jindisk.rs
+++ b/src/libos/crates/jindisk/src/jindisk.rs
@@ -61,7 +61,11 @@ impl JinDisk {
         let superblock = SuperBlock::init(disk.total_blocks());
 
         let checkpoint_disk_view = Self::checkpoint_disk_view(&superblock, &disk);
-        let checkpoint = Arc::new(Checkpoint::new(&superblock, checkpoint_disk_view));
+        let checkpoint = Arc::new(Checkpoint::new(
+            &superblock,
+            checkpoint_disk_view,
+            &root_key,
+        ));
 
         let index_disk_view = Self::index_disk_view(&superblock, &disk);
         let lsm_tree = Arc::new(LsmTree::new(index_disk_view, checkpoint.clone()));

--- a/src/libos/crates/jindisk/src/lib.rs
+++ b/src/libos/crates/jindisk/src/lib.rs
@@ -20,7 +20,7 @@
 //! - `read(lba: Lba, buf: &mut [u8])`
 //! - `write(lba: Lba, buf: &[u8])`
 //! - `flush()`
-//! - `trim(lbas: &[Lba])`
+//! - `discard(lbas: &[Lba])`
 //!
 //! JinDisk protects all block I/O through these operations transparently.
 //!
@@ -98,7 +98,7 @@ mod util;
 use self::checkpoint::Checkpoint;
 pub use self::config::{GiB, Hba, KiB, Lba, MiB, SEGMENT_SIZE};
 use self::data::{Cleaner, DataCache};
-use self::index::{LsmTree, Record};
+use self::index::{bit::Bit, LsmTree, Record};
 pub use self::jindisk::JinDisk;
 pub use self::superblock::SuperBlock;
 pub use self::util::cryption::{Cryption, DefaultCryptor};

--- a/src/libos/crates/jindisk/src/superblock.rs
+++ b/src/libos/crates/jindisk/src/superblock.rs
@@ -20,7 +20,7 @@ pub struct SuperBlock {
 
     /// Number of data segments
     pub num_data_segments: usize,
-    /// Number of over provisioning data segemnts
+    /// Number of over provisioning data segments
     pub num_over_provisioning: usize,
     /// Number of index segments
     pub num_index_segments: usize,

--- a/src/libos/crates/jindisk/src/util/cryption.rs
+++ b/src/libos/crates/jindisk/src/util/cryption.rs
@@ -25,28 +25,32 @@ pub type Iv = [u8; AUTH_ENC_IV_SIZE];
 
 /// Encryption/Decryption.
 pub trait Cryption {
-    /// Encrypt a block.
-    fn encrypt_block(plaintext: &[u8], key: &Key) -> CipherBlock;
+    /// Encrypt a block. (AEAD)
+    fn encrypt_block_aead(plaintext: &[u8], key: &Key) -> CipherBlock;
 
-    /// Decrypt a block.
-    fn decrypt_block(ciphertext: &[u8], key: &Key, meta: &CipherMeta) -> Result<[u8; BLOCK_SIZE]>;
+    /// Decrypt a block. (AEAD)
+    fn decrypt_block_aead(
+        ciphertext: &[u8],
+        key: &Key,
+        meta: &CipherMeta,
+    ) -> Result<[u8; BLOCK_SIZE]>;
 
-    /// Encrypt content of any length.
-    fn encrypt_arbitrary(plaintext: &[u8], ciphertext: &mut [u8], key: &Key) -> CipherMeta;
+    /// Encrypt content of any length. (AEAD)
+    fn encrypt_arbitrary_aead(plaintext: &[u8], ciphertext: &mut [u8], key: &Key) -> CipherMeta;
 
-    /// Decrypt content of any length.
-    fn decrypt_arbitrary(
+    /// Decrypt content of any length. (AEAD)
+    fn decrypt_arbitrary_aead(
         ciphertext: &[u8],
         plaintext: &mut [u8],
         key: &Key,
         meta: &CipherMeta,
     ) -> Result<()>;
 
-    /// Encrypt a block using symmetric key cipher(AES128 CTR mode)
-    fn symm_encrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]>;
+    /// Encrypt a block. (Non-AEAD)
+    fn encrypt_block(data: &[u8], key: &Key, iv: Option<&[u8]>) -> Result<[u8; BLOCK_SIZE]>;
 
-    /// Decrypt a block using symmetric key cipher(AES128 CTR mode)
-    fn symm_decrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]>;
+    /// Decrypt a block. (Non-AEAD)
+    fn decrypt_block(data: &[u8], key: &Key, iv: Option<&[u8]>) -> Result<[u8; BLOCK_SIZE]>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -104,37 +108,40 @@ impl CipherBlock {
 pub struct DefaultCryptor;
 
 impl Cryption for DefaultCryptor {
-    fn encrypt_block(plaintext: &[u8], key: &Key) -> CipherBlock {
-        Self::enc_block(plaintext, key)
+    fn encrypt_block_aead(plaintext: &[u8], key: &Key) -> CipherBlock {
+        Self::enc_block_aead(plaintext, key)
     }
 
-    fn decrypt_block(ciphertext: &[u8], key: &Key, meta: &CipherMeta) -> Result<[u8; BLOCK_SIZE]> {
-        Self::dec_block(ciphertext, key, meta)
+    fn decrypt_block_aead(
+        ciphertext: &[u8],
+        key: &Key,
+        meta: &CipherMeta,
+    ) -> Result<[u8; BLOCK_SIZE]> {
+        Self::dec_block_aead(ciphertext, key, meta)
     }
 
-    fn encrypt_arbitrary(plaintext: &[u8], ciphertext: &mut [u8], key: &Key) -> CipherMeta {
-        Self::enc_any(plaintext, ciphertext, key)
+    fn encrypt_arbitrary_aead(plaintext: &[u8], ciphertext: &mut [u8], key: &Key) -> CipherMeta {
+        Self::enc_any_aead(plaintext, ciphertext, key)
     }
 
-    fn decrypt_arbitrary(
+    fn decrypt_arbitrary_aead(
         ciphertext: &[u8],
         plaintext: &mut [u8],
         key: &Key,
         meta: &CipherMeta,
     ) -> Result<()> {
-        Self::dec_any(ciphertext, plaintext, key, meta)
+        Self::dec_any_aead(ciphertext, plaintext, key, meta)
     }
 
-    fn symm_encrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
-        Self::symm_enc_block(data, key)
+    fn encrypt_block(data: &[u8], key: &Key, iv: Option<&[u8]>) -> Result<[u8; BLOCK_SIZE]> {
+        Self::enc_block(data, key, iv)
     }
 
-    fn symm_decrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
-        Self::symm_dec_block(data, key)
+    fn decrypt_block(data: &[u8], key: &Key, iv: Option<&[u8]>) -> Result<[u8; BLOCK_SIZE]> {
+        Self::dec_block(data, key, iv)
     }
 }
 
-// TODO: Support symmetric encryption for blocks
 impl DefaultCryptor {
     #[allow(unused_mut)]
     pub fn gen_random_key() -> Key {
@@ -143,23 +150,22 @@ impl DefaultCryptor {
             if #[cfg(feature = "sgx")] {
                 thread_rng().fill_bytes(&mut rand_key);
             } else {
-                rand_bytes(&mut rand_key);
+                let _ = rand_bytes(&mut rand_key);
             }
         }
         rand_key
     }
 
-    #[allow(unused)]
-    fn enc_block(plaintext: &[u8], key: &Key) -> CipherBlock {
+    fn enc_block_aead(plaintext: &[u8], key: &Key) -> CipherBlock {
         debug_assert!(plaintext.len() == BLOCK_SIZE);
         let mut ciphertext: [u8; CIPHER_SIZE] = [0u8; CIPHER_SIZE];
-        let mut gmac = [0; 16];
+        let mut gmac = [0; AUTH_ENC_MAC_SIZE];
+        let nonce: Iv = [2; AUTH_ENC_IV_SIZE];
+        let aad: [u8; 0] = [0; 0];
 
         cfg_if! {
-            // AES-GCM
+            // AES-GCM-128
             if #[cfg(feature = "sgx")] {
-                let nonce: Iv = [2; 12];
-                let aad: [u8; 0] = [0; 0];
                 rsgx_rijndael128GCM_encrypt(
                     key,
                     plaintext,
@@ -169,10 +175,17 @@ impl DefaultCryptor {
                     &mut gmac,
                 )
                 .unwrap();
-            // Fake enc
             } else {
-                // TODO: add encryption for non-SGX builds
-                ciphertext.copy_from_slice(plaintext);
+                let cipher = encrypt_aead(
+                    Cipher::aes_128_gcm(),
+                    key,
+                    Some(&nonce),
+                    &aad,
+                    plaintext,
+                    &mut gmac,
+                )
+                .unwrap();
+                ciphertext.copy_from_slice(&cipher);
             }
         }
 
@@ -182,17 +195,16 @@ impl DefaultCryptor {
         }
     }
 
-    #[allow(unused)]
-    fn dec_block(ciphertext: &[u8], key: &Key, meta: &CipherMeta) -> Result<[u8; BLOCK_SIZE]> {
+    fn dec_block_aead(ciphertext: &[u8], key: &Key, meta: &CipherMeta) -> Result<[u8; BLOCK_SIZE]> {
         debug_assert!(ciphertext.len() == BLOCK_SIZE);
         let mut plaintext: [u8; BLOCK_SIZE] = [0u8; BLOCK_SIZE];
+        let gmac = meta.mac;
+        let nonce: Iv = [2; AUTH_ENC_IV_SIZE];
+        let aad: [u8; 0] = [0; 0];
 
         cfg_if! {
-            // AES-GCM
+            // AES128-GCM
             if #[cfg(feature = "sgx")] {
-                let gmac = meta.mac;
-                let nonce: Iv = [2; 12];
-                let aad: [u8; 0] = [0; 0];
                 let sgx_res =
                     rsgx_rijndael128GCM_decrypt(key, ciphertext, &nonce, &aad, &gmac, &mut plaintext[..]);
                 match sgx_res {
@@ -202,24 +214,31 @@ impl DefaultCryptor {
                     },
                     _ => return_errno!(EINVAL, "Unknown decryption error, should not happen"),
                 }
-            // Fake dec
             } else {
-                // TODO: add decryption for non-SGX builds
-                plaintext.copy_from_slice(ciphertext);
+                let plain = decrypt_aead(
+                    Cipher::aes_128_gcm(),
+                    key,
+                    Some(&nonce),
+                    &aad,
+                    &ciphertext,
+                    &gmac,
+                )
+                .unwrap();
+                plaintext.copy_from_slice(&plain);
             }
         }
 
         Ok(plaintext)
     }
 
-    fn enc_any(plaintext: &[u8], ciphertext: &mut [u8], key: &Key) -> CipherMeta {
+    fn enc_any_aead(plaintext: &[u8], ciphertext: &mut [u8], key: &Key) -> CipherMeta {
         debug_assert!(plaintext.len() == ciphertext.len());
-        let mut gmac = [0; 16];
-        let nonce: Iv = [2; 12];
+        let mut gmac = [0; AUTH_ENC_MAC_SIZE];
+        let nonce: Iv = [2; AUTH_ENC_IV_SIZE];
         let aad: [u8; 0] = [0; 0];
 
         cfg_if! {
-            // AES-GCM
+            // AES128-GCM
             if #[cfg(feature = "sgx")] {
                 rsgx_rijndael128GCM_encrypt(
                     key,
@@ -230,7 +249,6 @@ impl DefaultCryptor {
                     &mut gmac,
                 )
                 .unwrap();
-            // Fake enc
             } else {
                 let cipher = encrypt_aead(
                     Cipher::aes_128_gcm(),
@@ -248,7 +266,7 @@ impl DefaultCryptor {
         CipherMeta { mac: gmac }
     }
 
-    fn dec_any(
+    fn dec_any_aead(
         ciphertext: &[u8],
         plaintext: &mut [u8],
         key: &Key,
@@ -256,11 +274,11 @@ impl DefaultCryptor {
     ) -> Result<()> {
         debug_assert!(ciphertext.len() == plaintext.len());
         let gmac = meta.mac;
-        let nonce: Iv = [2; 12];
+        let nonce: Iv = [2; AUTH_ENC_IV_SIZE];
         let aad: [u8; 0] = [0; 0];
 
         cfg_if! {
-            // AES-GCM
+            // AES128-GCM
             if #[cfg(feature = "sgx")] {
                 let sgx_res =
                     rsgx_rijndael128GCM_decrypt(key, ciphertext, &nonce, &aad, &gmac, plaintext);
@@ -271,7 +289,6 @@ impl DefaultCryptor {
                     },
                     _ => return_errno!(EINVAL, "Unknown decryption error, should not happen"),
                 }
-            // Fake dec
             } else {
                 let plain = decrypt_aead(
                     Cipher::aes_128_gcm(),
@@ -288,9 +305,22 @@ impl DefaultCryptor {
         Ok(())
     }
 
-    fn symm_enc_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+    #[allow(unused_mut)]
+    fn enc_block(data: &[u8], key: &Key, iv: Option<&[u8]>) -> Result<[u8; BLOCK_SIZE]> {
+        debug_assert!(data.len() == BLOCK_SIZE);
         let mut output = [0u8; BLOCK_SIZE];
-        let mut ctr = [2u8; 16];
+        let mut ctr = {
+            const CTR_LEN: usize = 16;
+            let mut ctr = [2u8; CTR_LEN];
+            if let Some(iv) = iv {
+                if iv.len() == CTR_LEN {
+                    ctr.copy_from_slice(iv);
+                } else {
+                    return_errno!(EINVAL, "wrong iv length in AES-CTR");
+                }
+            }
+            ctr
+        };
 
         cfg_if! {
             // AES128-CTR
@@ -316,9 +346,22 @@ impl DefaultCryptor {
         Ok(output)
     }
 
-    fn symm_dec_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+    #[allow(unused_mut)]
+    fn dec_block(data: &[u8], key: &Key, iv: Option<&[u8]>) -> Result<[u8; BLOCK_SIZE]> {
+        debug_assert!(data.len() == BLOCK_SIZE);
         let mut output = [0u8; BLOCK_SIZE];
-        let mut ctr = [2u8; 16];
+        let mut ctr = {
+            const CTR_LEN: usize = 16;
+            let mut ctr = [2u8; CTR_LEN];
+            if let Some(iv) = iv {
+                if iv.len() == CTR_LEN {
+                    ctr.copy_from_slice(iv);
+                } else {
+                    return_errno!(EINVAL, "wrong iv length in AES-CTR");
+                }
+            }
+            ctr
+        };
 
         cfg_if! {
             // AES128-CTR
@@ -358,13 +401,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_enc_dec() {
+    fn test_enc_dec_aead() {
         let key = DefaultCryptor::gen_random_key();
 
         // encrypt_block & decrypt_block
         let plaintext = [0u8; BLOCK_SIZE];
-        let cipher_block = DefaultCryptor::encrypt_block(&plaintext, &key);
-        let decrypted = DefaultCryptor::decrypt_block(
+        let cipher_block = DefaultCryptor::encrypt_block_aead(&plaintext, &key);
+        let decrypted = DefaultCryptor::decrypt_block_aead(
             cipher_block.as_slice(),
             &key,
             cipher_block.cipher_meta(),
@@ -376,19 +419,19 @@ mod tests {
         const SIZE: usize = 5577;
         let plain = [5u8; SIZE];
         let mut cipher = [0u8; SIZE];
-        let cipher_meta = DefaultCryptor::encrypt_arbitrary(&plain, &mut cipher, &key);
+        let cipher_meta = DefaultCryptor::encrypt_arbitrary_aead(&plain, &mut cipher, &key);
         let mut decrypted = [0u8; SIZE];
-        let _ = DefaultCryptor::decrypt_arbitrary(&cipher, &mut decrypted, &key, &cipher_meta);
+        let _ = DefaultCryptor::decrypt_arbitrary_aead(&cipher, &mut decrypted, &key, &cipher_meta);
         assert_eq!(plain, decrypted);
     }
 
     #[test]
-    fn test_symm_enc_dec() {
+    fn test_enc_dec() {
         let key = DefaultCryptor::gen_random_key();
         let plaintext = [0u8; BLOCK_SIZE];
-        let ciphertext = DefaultCryptor::symm_encrypt_block(&plaintext, &key).unwrap();
+        let ciphertext = DefaultCryptor::encrypt_block(&plaintext, &key, None).unwrap();
         assert_ne!(plaintext, ciphertext);
-        let decrypted = DefaultCryptor::symm_decrypt_block(&ciphertext, &key).unwrap();
+        let decrypted = DefaultCryptor::decrypt_block(&ciphertext, &key, None).unwrap();
         assert_eq!(plaintext, decrypted);
     }
 }

--- a/src/libos/crates/jindisk/src/util/cryption.rs
+++ b/src/libos/crates/jindisk/src/util/cryption.rs
@@ -2,9 +2,13 @@
 use crate::prelude::*;
 use cfg_if::cfg_if;
 #[cfg(not(feature = "sgx"))]
-use openssl::symm::{decrypt_aead, encrypt_aead, Cipher};
+use openssl::rand::rand_bytes;
+#[cfg(not(feature = "sgx"))]
+use openssl::symm::{decrypt, decrypt_aead, encrypt, encrypt_aead, Cipher};
 #[cfg(feature = "sgx")]
 use sgx_rand::{thread_rng, Rng};
+#[cfg(feature = "sgx")]
+use sgx_tcrypto::{rsgx_aes_ctr_decrypt, rsgx_aes_ctr_encrypt};
 #[cfg(feature = "sgx")]
 use sgx_tcrypto::{rsgx_rijndael128GCM_decrypt, rsgx_rijndael128GCM_encrypt};
 #[cfg(feature = "sgx")]
@@ -37,6 +41,12 @@ pub trait Cryption {
         key: &Key,
         meta: &CipherMeta,
     ) -> Result<()>;
+
+    /// Encrypt a block using symmetric key cipher(AES128 CTR mode)
+    fn symm_encrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]>;
+
+    /// Decrypt a block using symmetric key cipher(AES128 CTR mode)
+    fn symm_decrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -114,6 +124,14 @@ impl Cryption for DefaultCryptor {
     ) -> Result<()> {
         Self::dec_any(ciphertext, plaintext, key, meta)
     }
+
+    fn symm_encrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        Self::symm_enc_block(data, key)
+    }
+
+    fn symm_decrypt_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        Self::symm_dec_block(data, key)
+    }
 }
 
 // TODO: Support symmetric encryption for blocks
@@ -121,8 +139,13 @@ impl DefaultCryptor {
     #[allow(unused_mut)]
     pub fn gen_random_key() -> Key {
         let mut rand_key = [5u8; AUTH_ENC_KEY_SIZE];
-        #[cfg(feature = "sgx")]
-        thread_rng().fill_bytes(&mut rand_key);
+        cfg_if! {
+            if #[cfg(feature = "sgx")] {
+                thread_rng().fill_bytes(&mut rand_key);
+            } else {
+                rand_bytes(&mut rand_key);
+            }
+        }
         rand_key
     }
 
@@ -264,6 +287,62 @@ impl DefaultCryptor {
         }
         Ok(())
     }
+
+    fn symm_enc_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        let mut output = [0u8; BLOCK_SIZE];
+        let mut ctr = [2u8; 16];
+
+        cfg_if! {
+            // AES128-CTR
+            if #[cfg(feature = "sgx")] {
+                let ctr_inc_bits = 128u32;
+                match rsgx_aes_ctr_encrypt(key, data, &mut ctr, ctr_inc_bits, &mut output) {
+                    Ok(_) => (),
+                    Err(_) => {
+                        return_errno!(EINVAL, "SGX: rsgx_aes_ctr_encrypt error");
+                    }
+                }
+            } else {
+                match encrypt(Cipher::aes_128_ctr(), key, Some(&ctr), data) {
+                    Ok(ciphertext) => {
+                        output.copy_from_slice(&ciphertext);
+                    },
+                    Err(_) => {
+                        return_errno!(EINVAL, "OPENSSL: aes_128_ctr encryption error");
+                    }
+                }
+            }
+        }
+        Ok(output)
+    }
+
+    fn symm_dec_block(data: &[u8], key: &Key) -> Result<[u8; BLOCK_SIZE]> {
+        let mut output = [0u8; BLOCK_SIZE];
+        let mut ctr = [2u8; 16];
+
+        cfg_if! {
+            // AES128-CTR
+            if #[cfg(feature = "sgx")] {
+                let ctr_inc_bits = 128u32;
+                match rsgx_aes_ctr_decrypt(key, data, &mut ctr, ctr_inc_bits, &mut output) {
+                    Ok(_) => (),
+                    Err(_) => {
+                        return_errno!(EINVAL, "SGX: rsgx_aes_ctr_decrypt error");
+                    }
+                }
+            } else {
+                match decrypt(Cipher::aes_128_ctr(), key, Some(&ctr), data) {
+                    Ok(ciphertext) => {
+                        output.copy_from_slice(&ciphertext);
+                    },
+                    Err(_) => {
+                        return_errno!(EINVAL, "OPENSSL: aes_128_ctr decryption error");
+                    }
+                }
+            }
+        }
+        Ok(output)
+    }
 }
 
 impl Encoder for Mac {
@@ -301,5 +380,15 @@ mod tests {
         let mut decrypted = [0u8; SIZE];
         let _ = DefaultCryptor::decrypt_arbitrary(&cipher, &mut decrypted, &key, &cipher_meta);
         assert_eq!(plain, decrypted);
+    }
+
+    #[test]
+    fn test_symm_enc_dec() {
+        let key = DefaultCryptor::gen_random_key();
+        let plaintext = [0u8; BLOCK_SIZE];
+        let ciphertext = DefaultCryptor::symm_encrypt_block(&plaintext, &key).unwrap();
+        assert_ne!(plaintext, ciphertext);
+        let decrypted = DefaultCryptor::symm_decrypt_block(&ciphertext, &key).unwrap();
+        assert_eq!(plaintext, decrypted);
     }
 }


### PR DESCRIPTION
This PR includes:
1. Add symm cryption API (AES-128-CTR) and apply to `DiskArray` @cqs21 https://github.com/occlum/occlum/pull/1289
2. Refactor cryption API (refer to [rust-openssl](https://docs.rs/openssl/0.10.54/openssl/symm/index.html))
3. Improve block reclamation part in compaction
4. Rename `trim()` to `discard()` for more accuracy in block device layer. Add an implementation, leave performance impact `TODO`.