### PR TITLE
Adjust the Ordering for all the atomics

### DIFF
--- a/src/libos/src/entry.rs
+++ b/src/libos/src/entry.rs
@@ -21,6 +21,10 @@ use sgx_tse::*;
 pub static mut INSTANCE_DIR: String = String::new();
 static mut ENCLAVE_PATH: String = String::new();
 
+/// Note about memory ordering:
+/// Although HAS_INIT is a global flag, it is just a signal and doesn't synchronize
+/// with other variables. Therefore, `Relaxed` can be used in both single-threaded
+/// and multi-threaded environments.
 lazy_static! {
     static ref INIT_ONCE: Once = Once::new();
     static ref HAS_INIT: AtomicBool = AtomicBool::new(false);
@@ -49,7 +53,7 @@ pub extern "C" fn occlum_ecall_init(
     instance_dir: *const c_char,
     file_buffer: *const host_file_buffer,
 ) -> i32 {
-    if HAS_INIT.load(Ordering::SeqCst) == true {
+    if HAS_INIT.load(Ordering::Relaxed) == true {
         return ecall_errno!(EEXIST);
     }
 
@@ -101,7 +105,7 @@ pub extern "C" fn occlum_ecall_init(
 
         interrupt::init();
 
-        HAS_INIT.store(true, Ordering::SeqCst);
+        HAS_INIT.store(true, Ordering::Relaxed);
 
         // Init boot up time stamp here.
         time::up_time::init();
@@ -135,7 +139,7 @@ pub extern "C" fn occlum_ecall_new_process(
     env: *const *const c_char,
     host_stdio_fds: *const HostStdioFds,
 ) -> i32 {
-    if HAS_INIT.load(Ordering::SeqCst) == false {
+    if HAS_INIT.load(Ordering::Relaxed) == false {
         return ecall_errno!(EAGAIN);
     }
 
@@ -164,7 +168,7 @@ pub extern "C" fn occlum_ecall_new_process(
 
 #[no_mangle]
 pub extern "C" fn occlum_ecall_exec_thread(libos_pid: i32, host_tid: i32) -> i32 {
-    if HAS_INIT.load(Ordering::SeqCst) == false {
+    if HAS_INIT.load(Ordering::Relaxed) == false {
         return ecall_errno!(EAGAIN);
     }
 
@@ -184,7 +188,7 @@ pub extern "C" fn occlum_ecall_exec_thread(libos_pid: i32, host_tid: i32) -> i32
 
 #[no_mangle]
 pub extern "C" fn occlum_ecall_kill(pid: i32, sig: i32) -> i32 {
-    if HAS_INIT.load(Ordering::SeqCst) == false {
+    if HAS_INIT.load(Ordering::Relaxed) == false {
         return ecall_errno!(EAGAIN);
     }
 
@@ -202,7 +206,7 @@ pub extern "C" fn occlum_ecall_kill(pid: i32, sig: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn occlum_ecall_broadcast_interrupts() -> i32 {
-    if HAS_INIT.load(Ordering::SeqCst) == false {
+    if HAS_INIT.load(Ordering::Relaxed) == false {
         return ecall_errno!(EAGAIN);
     }
 

--- a/src/libos/src/process/do_robust_list.rs
+++ b/src/libos/src/process/do_robust_list.rs
@@ -165,12 +165,17 @@ const FUTEX_OWNER_DIED: u32 = 0x4000_0000;
 const FUTEX_TID_MASK: u32 = 0x3FFF_FFFF;
 
 /// Wakeup one robust futex owned by the thread
+///
+/// Note about memory ordering:
+/// Here futex_val is just a shared variables between threads and doesn't synchronize
+/// with other variables. Therefore, `Relaxed` can be used in both single-threaded and
+/// multi-threaded environments.
 pub fn wake_robust_futex(futex_addr: *const i32, tid: pid_t) -> Result<()> {
     let futex_val = {
         check_ptr(futex_addr)?;
         unsafe { AtomicU32::from_mut(&mut *(futex_addr as *mut u32)) }
     };
-    let mut old_val = futex_val.load(Ordering::SeqCst);
+    let mut old_val = futex_val.load(Ordering::Relaxed);
     loop {
         // This futex may held by another thread, do nothing
         if old_val & FUTEX_TID_MASK != tid {
@@ -178,14 +183,14 @@ pub fn wake_robust_futex(futex_addr: *const i32, tid: pid_t) -> Result<()> {
         }
         let new_val = (old_val & FUTEX_WAITERS) | FUTEX_OWNER_DIED;
         if let Err(cur_val) =
-            futex_val.compare_exchange(old_val, new_val, Ordering::SeqCst, Ordering::SeqCst)
+            futex_val.compare_exchange(old_val, new_val, Ordering::Relaxed, Ordering::Relaxed)
         {
             // The futex value has changed, let's retry with current value
             old_val = cur_val;
             continue;
         }
         // Wakeup one waiter
-        if futex_val.load(Ordering::SeqCst) & FUTEX_WAITERS != 0 {
+        if futex_val.load(Ordering::Relaxed) & FUTEX_WAITERS != 0 {
             debug!("wake robust futex addr: {:?}", futex_addr);
             super::do_futex::futex_wake(futex_addr, 1)?;
         }

--- a/src/libos/src/process/task/mod.rs
+++ b/src/libos/src/process/task/mod.rs
@@ -8,6 +8,10 @@ pub use self::exec::{enqueue, enqueue_and_exec, exec};
 mod exec;
 
 /// Note: this definition must be in sync with task.h
+/// Note about memory ordering:
+/// Here user_fs is just a signal and doesn't synchronize with other
+/// variables. Therefore, `Relaxed` can be used in both single-threaded
+/// and multi-threaded environments.
 #[derive(Debug, Default)]
 #[repr(C)]
 pub struct Task {
@@ -51,10 +55,10 @@ impl Task {
     }
 
     pub(super) fn set_user_fs(&self, user_fs: usize) {
-        self.user_fs.store(user_fs, Ordering::SeqCst);
+        self.user_fs.store(user_fs, Ordering::Relaxed);
     }
 
     pub fn user_fs(&self) -> usize {
-        self.user_fs.load(Ordering::SeqCst)
+        self.user_fs.load(Ordering::Relaxed)
     }
 }

--- a/src/libos/src/untrusted/slice_alloc.rs
+++ b/src/libos/src/untrusted/slice_alloc.rs
@@ -5,6 +5,11 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// An memory allocator for slices, backed by a fixed-size, untrusted buffer
+///
+/// Note about memory ordering:
+/// Here buf_pos is used here for counting, not to synchronize access to other
+/// shared variables. Therefore, `Relaxed` can be used in both single-threaded
+/// and multi-threaded environments.
 pub struct UntrustedSliceAlloc {
     /// The pointer to the untrusted buffer
     buf_ptr: *mut u8,
@@ -48,7 +53,7 @@ impl UntrustedSliceAlloc {
             // Move self.buf_pos forward if enough space _atomically_.
             let old_pos = self
                 .buf_pos
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |old_pos| {
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old_pos| {
                     let new_pos = old_pos + new_slice_len;
                     if new_pos <= self.buf_size {
                         Some(new_pos)


### PR DESCRIPTION
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/entry.rs#L26
Here HAS_INIT is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter_queue.rs#L30
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter_queue.rs#L42
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter_queue.rs#L68
I think count needs to be synchronized with waker. The read operation of count needs to see the change of the waker field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter.rs#L120
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter.rs#L124
I think is_woken needs to be synchronized with host_eventfd. The read operation of is_woken needs to see the change of the host_eventfd field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter.rs#L155-L158
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/events/waiter.rs#L165-L171
In addition, fail does not synchronize other variables in the CAS operation, which can use Relaxed, and the host_enent fields need to be synchronized in success, so acquire needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/task/mod.rs#L54
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/task/mod.rs#L58
Here user_fs is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/term_status.rs#L21
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/term_status.rs#L27
I think exited needs to be synchronized with status. The read operation of exited needs to see the change of the status field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_futex.rs#L444
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_futex.rs#L446
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_futex.rs#L454
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_futex.rs#L473
I think is_woken needs to be synchronized with thread. The read operation of exited needs to see the change of the thread field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/untrusted/slice_alloc.rs#L49-L51
I think the use of ordering here is irregular, buf_pos is used here for counting, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_robust_list.rs#L173
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_robust_list.rs#L181
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/process/do_robust_list.rs#L188
Here futex_val is just a shared variables between threads and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/net/io_multiplexing/epoll/epoll_file.rs#L175
https://github.com/occlum/occlum/blob/e2f7e6109a3074e64730a950e62b1037d9e5e17c/src/libos/src/net/io_multiplexing/epoll/epoll_file.rs#L288
Here is_deleted is just a shared variables between threads and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.