### PR TITLE
Log cfg

### DIFF
--- a/docs/readthedocs/docs/source/how_to_debug.md
+++ b/docs/readthedocs/docs/source/how_to_debug.md
@@ -5,3 +5,5 @@ To debug an app running upon Occlum, one can harness Occlum's builtin support fo
 Meanwhile, one can use `occlum mount` command to access and manipulate the secure filesystem for debug purpose.
 
 If the cause of a problem does not seem to be the app but Occlum itself, then one can take a glimpse into the inner workings of Occlum by checking out its log. Occlum's log level can be adjusted through `OCCLUM_LOG_LEVEL` environment variable. It has six levels: `off`, `error`, `warn`, `debug`, `info`, and `trace`. The default value is `off`, i.e., showing no log messages at all. The most verbose level is `trace`.
+
+The Occlum log output could be disabled totally for better security by setting `metadata.disable_log=true` in `Occlum.json` before building the Occlum instance. For detail please refer [Occlum Configuration](https://occlum.readthedocs.io/en/latest/occlum_configuration.html).

--- a/docs/readthedocs/docs/source/occlum_configuration.md
+++ b/docs/readthedocs/docs/source/occlum_configuration.md
@@ -61,7 +61,14 @@ The template of `Occlum.json` is shown below.
         "version_number": 0,
         // Whether the enclave is debuggable through special SGX instructions.
         // For production enclave, it is IMPORTANT to set this value to false.
-        "debuggable": true
+        "debuggable": true,
+        // Whether the enclave is allowable to print Occlum log.
+        // Optional, if not set, in default it is false for debuggable enclave
+        // but true for production/release enclave for better security.
+        // Production/release enclave could explicitly set it false to have log
+        // output for debugging purpose. In this case, error log level is the
+        // only allowed log level.
+        "disable_log": false,
     },
     // Features
     "feature": {

--- a/src/libos/src/entry.rs
+++ b/src/libos/src/entry.rs
@@ -60,24 +60,17 @@ pub extern "C" fn occlum_ecall_init(
 
     assert!(!instance_dir.is_null());
 
-    let log_level = {
-        let input_log_level = match parse_log_level(log_level) {
-            Err(e) => {
-                eprintln!("invalid log level: {}", e.backtrace());
-                return ecall_errno!(EINVAL);
-            }
-            Ok(log_level) => log_level,
-        };
-        // Use the input log level if and only if the enclave allows debug
-        if sgx_allow_debug() {
-            input_log_level
-        } else {
-            LevelFilter::Off
+    let log_level = match parse_log_level(log_level) {
+        Err(e) => {
+            eprintln!("invalid log level: {}", e.backtrace());
+            return ecall_errno!(EINVAL);
         }
+        Ok(log_level) => log_level,
     };
 
     INIT_ONCE.call_once(|| {
         // Init the log infrastructure first so that log messages will be printed afterwards
+        // The log level may be set to off later if disable_log is true in user configuration
         util::log::init(log_level);
 
         let report = rsgx_self_report();

--- a/tools/gen_internal_conf/src/main.rs
+++ b/tools/gen_internal_conf/src/main.rs
@@ -487,6 +487,20 @@ fn main() {
             app_config.unwrap()
         };
 
+        // If the user doesn't provide a value, set it false unless it is release enclave.
+        // If the user provides a value, just use it.
+        let disable_log = {
+            if occlum_config.metadata.disable_log.is_none() {
+                if occlum_config.metadata.debuggable {
+                    false
+                } else {
+                    true
+                }
+            } else {
+                occlum_config.metadata.disable_log.unwrap()
+            }
+        };
+
         let occlum_json_config = InternalOcclumJson {
             resource_limits: InternalResourceLimits {
                 user_space_init_size: config_user_space_init_size.to_string() + "B",
@@ -498,6 +512,7 @@ fn main() {
                 default_mmap_size: occlum_config.process.default_mmap_size,
             },
             env: occlum_config.env,
+            disable_log: disable_log,
             app: app_config,
             feature: occlum_config.feature.clone(),
         };
@@ -728,6 +743,8 @@ struct OcclumMetadata {
     product_id: u32,
     version_number: u32,
     debuggable: bool,
+    #[serde(default)]
+    disable_log: Option<bool>,
     enable_kss: bool,
     family_id: OcclumMetaID,
     ext_prod_id: OcclumMetaID,
@@ -823,6 +840,7 @@ struct InternalOcclumJson {
     resource_limits: InternalResourceLimits,
     process: OcclumProcess,
     env: serde_json::Value,
+    disable_log: bool,
     app: serde_json::Value,
     feature: OcclumFeature,
 }


### PR DESCRIPTION
Add `metatata.disable_log` to decide whether the enclave is allowable to print Occlum log.