### PR TITLE
Fune-tune the Ordering for all the atomics

### DIFF
--- a/src/libos/src/events/waiter_queue.rs
+++ b/src/libos/src/events/waiter_queue.rs
@@ -11,6 +11,21 @@ use crate::prelude::*;
 ///
 /// While the queue is conceptually for `Waiter`s, it internally maintains a list
 /// of `Waker`s.
+/// 
+/// Note about memory ordering:
+/// Here count needs to be synchronized with wakers. The read operation of count
+/// needs to see the change of the waker field. Just `Acquire` or `Release` needs
+/// to be used to make all the change of the wakers visible to us.
+///
+/// Regarding the usage of functions like fetch_add and fetch_sub, they perform
+/// atomic addition or subtraction operations. The memory ordering parameter for
+/// these functions can be chosen from options such as `Relaxed`, `Acquire`, `Release`,
+/// `AcqRel` and `SeqCst`. It is important to select the appropriate memory ordering
+/// based on the corresponding usage scenario.
+///
+/// In this code snippet, the count variable is synchronized with the wakers field.
+/// In this case, we only need to ensure that waker.lock() occurs before count.
+/// Although it is safer to use AcqRel，here using `Release` would be enough.
 pub struct WaiterQueue {
     count: AtomicUsize,
     wakers: SgxMutex<VecDeque<Waker>>,
@@ -27,7 +42,9 @@ impl WaiterQueue {
 
     /// Returns whether the queue is empty.
     pub fn is_empty(&self) -> bool {
-        self.count.load(Ordering::SeqCst) == 0
+        // Here is_empty function is only used in line 76 below. And when calling this, it
+        // doesn't need to synchronize with the wakers. Therefore, Relaxed can be enough.
+        self.count.load(Ordering::Relaxed) == 0
     }
 
     /// Reset a waiter and enqueue it.
@@ -39,7 +56,7 @@ impl WaiterQueue {
         waiter.reset();
 
         let mut wakers = self.wakers.lock().unwrap();
-        self.count.fetch_add(1, Ordering::SeqCst);
+        self.count.fetch_add(1, Ordering::Release);
         wakers.push_back(waiter.waker());
     }
 
@@ -65,7 +82,7 @@ impl WaiterQueue {
             let mut wakers = self.wakers.lock().unwrap();
             let max_count = max_count.min(wakers.len());
             let to_wake: Vec<Waker> = wakers.drain(..max_count).collect();
-            self.count.fetch_sub(to_wake.len(), Ordering::SeqCst);
+            self.count.fetch_sub(to_wake.len(), Ordering::Release);
             to_wake
         };
 

--- a/src/libos/src/process/do_robust_list.rs
+++ b/src/libos/src/process/do_robust_list.rs
@@ -165,12 +165,18 @@ const FUTEX_OWNER_DIED: u32 = 0x4000_0000;
 const FUTEX_TID_MASK: u32 = 0x3FFF_FFFF;
 
 /// Wakeup one robust futex owned by the thread
+/// 
+/// Note about memory ordering:
+/// Here futex_val is just a shared variables between threads and doesn't synchronize
+/// with other variables. Compare_exchange guarantees that the operation is on the
+/// "latest" value. Therefore, `Relaxed` can be used in both single-threaded and
+/// multi-threaded environments.
 pub fn wake_robust_futex(futex_addr: *const i32, tid: pid_t) -> Result<()> {
     let futex_val = {
         check_ptr(futex_addr)?;
         unsafe { AtomicU32::from_mut(&mut *(futex_addr as *mut u32)) }
     };
-    let mut old_val = futex_val.load(Ordering::SeqCst);
+    let mut old_val = futex_val.load(Ordering::Relaxed);
     loop {
         // This futex may held by another thread, do nothing
         if old_val & FUTEX_TID_MASK != tid {
@@ -178,14 +184,14 @@ pub fn wake_robust_futex(futex_addr: *const i32, tid: pid_t) -> Result<()> {
         }
         let new_val = (old_val & FUTEX_WAITERS) | FUTEX_OWNER_DIED;
         if let Err(cur_val) =
-            futex_val.compare_exchange(old_val, new_val, Ordering::SeqCst, Ordering::SeqCst)
+            futex_val.compare_exchange(old_val, new_val, Ordering::Relaxed, Ordering::Relaxed)
         {
             // The futex value has changed, let's retry with current value
             old_val = cur_val;
             continue;
         }
         // Wakeup one waiter
-        if futex_val.load(Ordering::SeqCst) & FUTEX_WAITERS != 0 {
+        if futex_val.load(Ordering::Relaxed) & FUTEX_WAITERS != 0 {
             debug!("wake robust futex addr: {:?}", futex_addr);
             super::do_futex::futex_wake(futex_addr, 1)?;
         }

--- a/src/libos/src/process/task/mod.rs
+++ b/src/libos/src/process/task/mod.rs
@@ -8,6 +8,11 @@ pub use self::exec::{enqueue, enqueue_and_exec, exec};
 mod exec;
 
 /// Note: this definition must be in sync with task.h
+/// 
+/// Note about memory ordering:
+/// Here user_fs is just a signal and doesn't synchronize with other
+/// variables. Therefore, `Relaxed` can be used in both single-threaded
+/// and multi-threaded environments.
 #[derive(Debug, Default)]
 #[repr(C)]
 pub struct Task {
@@ -51,10 +56,10 @@ impl Task {
     }
 
     pub(super) fn set_user_fs(&self, user_fs: usize) {
-        self.user_fs.store(user_fs, Ordering::SeqCst);
+        self.user_fs.store(user_fs, Ordering::Relaxed);
     }
 
     pub fn user_fs(&self) -> usize {
-        self.user_fs.load(Ordering::SeqCst)
+        self.user_fs.load(Ordering::Relaxed)
     }
 }

--- a/src/libos/src/untrusted/slice_alloc.rs
+++ b/src/libos/src/untrusted/slice_alloc.rs
@@ -5,6 +5,12 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// An memory allocator for slices, backed by a fixed-size, untrusted buffer
+/// 
+/// Note about memory ordering:
+/// Here buf_pos is used here for counting, not to synchronize access to other
+/// shared variables. Fetch_update guarantees that the operation is on the
+/// "latest" value. Therefore, `Relaxed` can be used in both single-threaded and
+/// multi-threaded environments.
 pub struct UntrustedSliceAlloc {
     /// The pointer to the untrusted buffer
     buf_ptr: *mut u8,
@@ -48,7 +54,7 @@ impl UntrustedSliceAlloc {
             // Move self.buf_pos forward if enough space _atomically_.
             let old_pos = self
                 .buf_pos
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |old_pos| {
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old_pos| {
                     let new_pos = old_pos + new_slice_len;
                     if new_pos <= self.buf_size {
                         Some(new_pos)


### PR DESCRIPTION
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/entry.rs#L26
HAS_INIT need to synchronize the relevant resources in interrupt::init(). The read operation of HAS_INIT needs to see the change of the resources. I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter_queue.rs#L30
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter_queue.rs#L42
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter_queue.rs#L68
I think count needs to be synchronized with waker. The read operation of count needs to see the change of the waker field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
I think count needs to be synchronized with waker. The read operation of count needs to see the change of the waker field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter.rs#L120
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter.rs#L124
I think is_woken needs to be synchronized with host_eventfd. The read operation of is_woken needs to see the change of the host_eventfd field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter.rs#L155-L158
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/events/waiter.rs#L165-L171
In addition, fail does not synchronize other variables in the CAS operation, which can use Relaxed, and the host_enent fields need to be synchronized in success, so acquire needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/task/mod.rs#L54
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/task/mod.rs#L58
Here user_fs is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/term_status.rs#L21
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/term_status.rs#L27
I think exited needs to be synchronized with status. The read operation of exited needs to see the change of the status field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_futex.rs#L444
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_futex.rs#L446
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_futex.rs#L454
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_futex.rs#L473
I think is_woken needs to be synchronized with thread. The read operation of exited needs to see the change of the thread field. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/untrusted/slice_alloc.rs#L49-L51
I think the use of ordering here is irregular, buf_pos is used here for counting, not to synchronize access to other shared variables. Fetch_update guarantees that the operation is on the "latest" value. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_robust_list.rs#L173
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_robust_list.rs#L181
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/process/do_robust_list.rs#L188
Here futex_val is just a shared variables between threads and doesn't synchronize with other variables. Compare_exchange guarantees that the operation is on the "latest" value. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/net/io_multiplexing/epoll/epoll_file.rs#L175
Here is_deleted needs to be synchronized with entry.The read operation of is_deleted needs to see the entry has been deleted from the interest list. Therefore, the load operation of is_deleted requires the use of Acquire.
https://github.com/occlum/occlum/blob/f54eabfa92319490e1b13075b28fef2d3d9129fd/src/libos/src/net/io_multiplexing/epoll/epoll_file.rs#L285-L288
There is a data-dependency, so this cannot be re-ordered, `Relaxed` should be enough.