### PR TITLE
[vm] Avoid early munmap of shm

### DIFF
--- a/src/libos/src/ipc/shm.rs
+++ b/src/libos/src/ipc/shm.rs
@@ -4,7 +4,8 @@ use crate::fs::FileMode;
 use crate::process::{do_getegid, do_geteuid, gid_t, uid_t, ThreadRef};
 use crate::time::{do_gettimeofday, time_t};
 use crate::vm::{
-    ChunkRef, VMInitializer, VMMapOptionsBuilder, VMPerms, VMRange, USER_SPACE_VM_MANAGER,
+    ChunkRef, MunmapChunkFlag, VMInitializer, VMMapOptionsBuilder, VMPerms, VMRange,
+    USER_SPACE_VM_MANAGER,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -212,7 +213,7 @@ impl Drop for ShmSegment {
         assert!(self.process_set.len() == 0);
         USER_SPACE_VM_MANAGER
             .internal()
-            .munmap_chunk(&self.chunk, None, false);
+            .munmap_chunk(&self.chunk, None, MunmapChunkFlag::Default);
     }
 }
 

--- a/src/libos/src/vm/mod.rs
+++ b/src/libos/src/vm/mod.rs
@@ -80,6 +80,7 @@ pub use self::chunk::{ChunkRef, ChunkType};
 pub use self::process_vm::{MMapFlags, MRemapFlags, MSyncFlags, ProcessVM, ProcessVMBuilder};
 pub use self::user_space_vm::USER_SPACE_VM_MANAGER;
 pub use self::vm_area::VMArea;
+pub use self::vm_manager::MunmapChunkFlag;
 pub use self::vm_perms::VMPerms;
 pub use self::vm_range::VMRange;
 pub use self::vm_util::{VMInitializer, VMMapOptionsBuilder};

--- a/src/libos/src/vm/process_vm.rs
+++ b/src/libos/src/vm/process_vm.rs
@@ -3,6 +3,7 @@ use super::*;
 use super::chunk::*;
 use super::user_space_vm::USER_SPACE_VM_MANAGER;
 use super::vm_area::VMArea;
+use super::vm_manager::MunmapChunkFlag;
 use super::vm_perms::VMPerms;
 use super::vm_util::{
     FileBacked, VMInitializer, VMMapAddr, VMMapOptions, VMMapOptionsBuilder, VMRemapOptions,
@@ -214,7 +215,7 @@ impl<'a, 'b> ProcessVMBuilder<'a, 'b> {
         chunks.iter().for_each(|chunk| {
             USER_SPACE_VM_MANAGER
                 .internal()
-                .munmap_chunk(chunk, None, false);
+                .munmap_chunk(chunk, None, MunmapChunkFlag::Default);
         });
     }
 
@@ -312,9 +313,11 @@ impl Drop for ProcessVM {
         mem_chunks
             .drain_filter(|chunk| chunk.is_single_vma())
             .for_each(|chunk| {
-                USER_SPACE_VM_MANAGER
-                    .internal()
-                    .munmap_chunk(&chunk, None, false);
+                USER_SPACE_VM_MANAGER.internal().munmap_chunk(
+                    &chunk,
+                    None,
+                    MunmapChunkFlag::OnProcessExit,
+                );
             });
 
         assert!(mem_chunks.len() == 0);


### PR DESCRIPTION
This PR fixes an early munmap bug in posix shm, inspired by https://github.com/occlum/occlum/issues/1392

TODO: Add the multi-thread rust demo that could testify the above bugfix