### PR TITLE
Enable copy_bom to find dependences directories which end with '/'

### DIFF
--- a/tools/copy_bom/README.md
+++ b/tools/copy_bom/README.md
@@ -47,7 +47,7 @@ The second part in the line indicates where to find shared libraries. All paths 
 
 # known limitations
 
-- The use of wildcard(like *) in files or directories is not supported. It may result in `copy_bom` behaving incorrectly.
+- The use of wildcard(like *) in files or directories is not supported. It may result in `copy_bom` behaving incorrectly. To achieve a similar purpose, directly add `/` after the directory name to copy all contents in the directory while not copying the directory itself. 
 - If we create symbolic link in bom file, it will always delete the old link and create a new one. It will change the modification time of the symbolic link.
 - Environmental variables pointing to an empty value may fail to resolve.
 

--- a/tools/copy_bom/example.yaml
+++ b/tools/copy_bom/example.yaml
@@ -36,3 +36,11 @@ targets:
     mkdirs:
       - python-occlum
       - python-occlum/bin
+  - target: /etc
+    copy:
+      - dirs:
+        # If there's a '/' as the postfix in directory name, copy the contents in 
+        # directories, not including the directory itself.
+        # cp -r /etc/opt/ /etc
+        - /etc/opt/
+

--- a/tools/copy_bom/src/bom.rs
+++ b/tools/copy_bom/src/bom.rs
@@ -461,11 +461,7 @@ impl BomManagement {
         // get all files in copydirs. filter directories and symlinks
         let mut files_in_copied_dirs = Vec::new();
         for (src, dest) in dirs_to_copy {
-            let dirname = PathBuf::from(src)
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .to_string();
+            let dirname = src.split('/').last().unwrap();
             let dest_dir = PathBuf::from(dest)
                 .join(dirname)
                 .to_string_lossy()


### PR DESCRIPTION
The original way to get filename is incorrect for directories which end with '/'.

For path like `/dev/pts/`, if we use the original way,
```rust
let pathbuf = PathBuf::from("/dev/pts/");
let filename = pathbuf.filename().unwrap(); 
```
`filename` will be `pts`. However, an empty filename is indeed what we want.