### PR TITLE
Improve network performance by reducing ocalls

### DIFF
--- a/src/libos/src/net/socket/host/recv.rs
+++ b/src/libos/src/net/socket/host/recv.rs
@@ -1,6 +1,18 @@
 use super::*;
 use crate::untrusted::{SliceAsMutPtrAndLen, SliceAsPtrAndLen, UntrustedSliceAlloc};
 
+#[derive(Debug)]
+pub struct Receiver {
+    alloc: UntrustedSliceAlloc,
+}
+
+impl Receiver {
+    pub fn new() -> Result<Self> {
+        let alloc = UntrustedSliceAlloc::new(RECV_BUF_SIZE)?;
+        Ok(Self { alloc })
+    }
+}
+
 impl HostSocket {
     pub fn recv(&self, buf: &mut [u8], flags: RecvFlags) -> Result<usize> {
         let (bytes_recvd, _) = self.recvfrom(buf, flags)?;
@@ -32,11 +44,24 @@ impl HostSocket {
         mut control: Option<&mut [u8]>,
     ) -> Result<(usize, usize, usize, MsgHdrFlags)> {
         let data_length = data.iter().map(|s| s.len()).sum();
-        let u_allocator = UntrustedSliceAlloc::new(data_length)?;
+        let mut receiver: SgxMutexGuard<'_, Receiver>;
+        let mut ocall_alloc;
+        // Allocated slice in untrusted memory region
+        let u_allocator = if data_length > RECV_BUF_SIZE {
+            // Ocall allocator
+            ocall_alloc = UntrustedSliceAlloc::new(data_length)?;
+            &mut ocall_alloc
+        } else {
+            // Inner allocator, lock buffer until recv ocall completion
+            receiver = self.receiver.lock().unwrap();
+            &mut receiver.alloc
+        };
+
         let mut u_data = {
             let mut bufs = Vec::new();
             for ref buf in data.iter() {
-                bufs.push(u_allocator.new_slice_mut(buf.len())?);
+                let u_slice = u_allocator.new_slice_mut(buf.len())?;
+                bufs.push(u_slice);
             }
             bufs
         };
@@ -52,6 +77,7 @@ impl HostSocket {
                 break;
             }
         }
+        u_allocator.reset();
         Ok(retval)
     }
 


### PR DESCRIPTION
This PR improve 50% tcp performance by reducing ocalls.

![image](https://github.com/occlum/occlum/assets/36983421/3809b6ed-0e63-47fb-99d2-d77ea306f828)
