### PR TITLE
[libos] Lower some frequent error log to warn level

### DIFF
--- a/src/libos/src/syscall/mod.rs
+++ b/src/libos/src/syscall/mod.rs
@@ -422,6 +422,15 @@ macro_rules! process_syscall_table_with_callback {
             (Userfaultfd = 323) => handle_unsupported(),
             (Membarrier = 324) => handle_unsupported(),
             (Mlock2 = 325) => handle_unsupported(),
+            (CopyFileRange = 326) => handle_unsupported(),
+            (Preadv2 = 327) => handle_unsupported(),
+            (Pwritev2 = 328) => handle_unsupported(),
+            (PkeyMprotect = 329) => handle_unsupported(),
+            (PkeyAlloc = 330) => handle_unsupported(),
+            (PkeyFree = 331) => handle_unsupported(),
+            (Statx = 332) => handle_unsupported(),
+            (IoPgetevents = 333) => handle_unsupported(),
+            (Rseq = 334) => handle_unsupported(),
 
             // Occlum-specific system calls
             (SpawnGlibc = 359) => do_spawn_for_glibc(child_pid_ptr: *mut u32, path: *const i8, argv: *const *const i8, envp: *const *const i8, fa: *const SpawnFileActions, attribute_list: *const posix_spawnattr_t),

--- a/src/libos/src/syscall/mod.rs
+++ b/src/libos/src/syscall/mod.rs
@@ -697,18 +697,20 @@ fn do_syscall(user_context: &mut CpuContext) {
 
                 // All other log levels require errors to be outputed. But
                 // some errnos are usually benign and may occur in a very high
-                // frequency. So we want to ignore them to keep noises at a
-                // minimum level in the log.
+                // frequency. So we want to lower them to warn level to keep noises
+                // at a minimum level in the error log.
                 //
                 // TODO: use a smarter, frequency-based strategy to decide whether
                 // to suppress error messages.
                 match errno {
-                    EAGAIN | ETIMEDOUT => false,
+                    EAGAIN | ETIMEDOUT | ENOENT | ENOTTY => false,
                     _ => true,
                 }
             };
             if should_log_err(e.errno()) {
                 error!("Error = {}", e.backtrace());
+            } else {
+                warn!("Error = {}", e.backtrace());
             }
 
             let retval = -(e.errno() as isize);

--- a/src/libos/src/vm/process_vm.rs
+++ b/src/libos/src/vm/process_vm.rs
@@ -484,10 +484,12 @@ impl ProcessVM {
             *brk_guard = brk;
             Ok(brk)
         } else {
-            if brk < heap_start {
-                error!("New brk address is too low");
+            if brk == 0 {
+                debug!("Try get current program break address")
+            } else if brk < heap_start {
+                warn!("New brk address is too low");
             } else if brk > heap_end {
-                error!("New brk address is too high");
+                warn!("New brk address is too high");
             }
 
             Ok(*brk_guard)


### PR DESCRIPTION
1. Lower ENOENT and ENOTTY to warn level
2. Lower BRK error to warn level