### PR TITLE
[config] Add "feature" field to Occlum.json

### DIFF
--- a/.github/workflows/composite_action/hw/action.yml
+++ b/.github/workflows/composite_action/hw/action.yml
@@ -87,3 +87,10 @@ runs:
       run: docker exec ${{ env.CONTAINER_NAME }} bash -c "source /opt/intel/sgxsdk/environment; cd /root/occlum; ${{ inputs.build-envs}} make install"
       shell: bash
 
+    # When there comes new features, the configuration should be enabled accordingly
+    - name: Configure Occlum features
+      run: |
+        if [[ "${{ matrix.self_runner[2] }}" == "EDMM" ]]; then
+          docker exec ${{ env.CONTAINER_NAME }} bash -c "jq '.feature.enable_posix_shm = true' /opt/occlum/etc/template/Occlum.json > /tmp.json && mv /tmp.json /opt/occlum/etc/template/Occlum.json"
+        fi;
+      shell: bash

--- a/demos/java/run_java_on_occlum.sh
+++ b/demos/java/run_java_on_occlum.sh
@@ -36,7 +36,7 @@ init_instance() {
 }
 
 update_pku_config() {
-    new_json="$(jq '.metadata.pkru = 1' Occlum.json)" && echo "${new_json}" > Occlum.json
+    new_json="$(jq '.feature.pkru = 1' Occlum.json)" && echo "${new_json}" > Occlum.json
 }
 
 build_web() {

--- a/demos/python/python_glibc/python3.10-multiprocessing/run_python3.10_on_occlum.sh
+++ b/demos/python/python_glibc/python3.10-multiprocessing/run_python3.10_on_occlum.sh
@@ -19,6 +19,7 @@ fi
 
 new_json="$(jq '.resource_limits.user_space_size = "1000MB" |
         .resource_limits.kernel_space_heap_size = "300MB" |
+        .feature.enable_posix_shm = true |
         .env.default += ["PYTHONHOME=/opt/python-occlum", "PATH=/bin"]' Occlum.json)" && \
 echo "${new_json}" > Occlum.json
 occlum build

--- a/demos/sofaboot/.gitignore
+++ b/demos/sofaboot/.gitignore
@@ -1,0 +1,2 @@
+occlum_instance
+sofa-boot-guides

--- a/docs/pku_manual.md
+++ b/docs/pku_manual.md
@@ -106,7 +106,7 @@ PKU feature can only be enabled in `HW` mode. Whether to turn on PKU feature is 
 ```js
 {
     // ...
-    "metadata": {
+    "feature": {
         // "pkru" = 0: PKU feature must be disabled
         // "pkru" = 1: PKU feature must be enabled
         // "pkru" = 2: PKU feature is enabled if the platform supports it
@@ -118,8 +118,8 @@ PKU feature can only be enabled in `HW` mode. Whether to turn on PKU feature is 
 
 Users have three options for PKU feature:
 
-1. If `metadata.pkru` == 0: The PKU feature must disabled in Occlum. It is the default value. Since docker has not supported PKU related syscalls in container environment by default, Occlum turns off PKU feature in default configuration.
+1. If `feature.pkru` == 0: The PKU feature must disabled in Occlum. It is the default value. Since docker has not supported PKU related syscalls in container environment by default, Occlum turns off PKU feature in default configuration.
 
-2. If `metadata.pkru` == 1: The PKU feature must enabled in Occlum. If CPU on the platform does not support PKU, then enclave cannot be successfully initialized.
+2. If `feature.pkru` == 1: The PKU feature must enabled in Occlum. If CPU on the platform does not support PKU, then enclave cannot be successfully initialized.
 
-3. If `metadata.pkru` == 2: If CPU supports PKU, also OS enables PKU feature, PKU feature is turned on in Occlum.
+3. If `feature.pkru` == 2: If CPU supports PKU, also OS enables PKU feature, PKU feature is turned on in Occlum.

--- a/docs/readthedocs/docs/source/occlum_configuration.md
+++ b/docs/readthedocs/docs/source/occlum_configuration.md
@@ -61,7 +61,10 @@ The template of `Occlum.json` is shown below.
         "version_number": 0,
         // Whether the enclave is debuggable through special SGX instructions.
         // For production enclave, it is IMPORTANT to set this value to false.
-        "debuggable": true,
+        "debuggable": true
+    },
+    // Features
+    "feature": {
         // Whether to turn on PKU feature in Occlum
         // Occlum uses PKU for isolation between LibOS and userspace program,
         // It is useful for developers to detect potential bugs.
@@ -69,7 +72,15 @@ The template of `Occlum.json` is shown below.
         // "pkru" = 0: PKU feature must be disabled
         // "pkru" = 1: PKU feature must be enabled
         // "pkru" = 2: PKU feature is enabled if the platform supports it
-        "pkru": 0
+        "pkru": 0,
+        // Whether to enable POSIX shared memory feature.
+        // Enabling POSIX shm allows processes to communicate by sharing a region of memory.
+        // 
+        // Set "enable_posix_shm" to true, the syscall `mmap` with flag `MAP_SHARED` 
+        // is supported more comprehensively, implies that the file-backed memory mapping
+        // become shared among processes.
+        // More API information of POSIX shm is listed in [shm_overview](https://man7.org/linux/man-pages/man7/shm_overview.7.html).
+        "enable_posix_shm": false
     },
     // Mount points and their file systems
     //

--- a/etc/template/Occlum.json
+++ b/etc/template/Occlum.json
@@ -34,8 +34,11 @@
             "high": "0x0",
             "low": "0x0"
         },
-        "pkru": 0,
         "amx": 0
+    },
+    "feature": {
+        "pkru": 0,
+        "enable_posix_shm": false
     },
     "mount": [
         {

--- a/src/libos/src/config.rs
+++ b/src/libos/src/config.rs
@@ -104,6 +104,7 @@ pub struct Config {
     pub process: ConfigProcess,
     pub env: ConfigEnv,
     pub app: Vec<ConfigApp>,
+    pub feature: ConfigFeature,
 }
 
 #[derive(Debug)]
@@ -138,6 +139,12 @@ pub struct ConfigApp {
     pub entry_points: Vec<PathBuf>,
     pub stage: String,
     pub mount: Vec<ConfigMount>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfigFeature {
+    pub pkru: u32,
+    pub enable_posix_shm: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -184,7 +191,6 @@ impl Config {
         let resource_limits = ConfigResourceLimits::from_input(&input.resource_limits)?;
         let process = ConfigProcess::from_input(&input.process)?;
         let env = ConfigEnv::from_input(&input.env)?;
-
         let app = {
             let mut app = Vec::new();
             for input_app in &input.app {
@@ -192,12 +198,14 @@ impl Config {
             }
             app
         };
+        let feature = ConfigFeature::from_input(&input.feature)?;
 
         Ok(Config {
             resource_limits,
             process,
             env,
             app,
+            feature,
         })
     }
 
@@ -271,6 +279,15 @@ impl ConfigApp {
             stage,
             entry_points,
             mount,
+        })
+    }
+}
+
+impl ConfigFeature {
+    fn from_input(input: &InputConfigFeature) -> Result<ConfigFeature> {
+        Ok(ConfigFeature {
+            pkru: input.pkru,
+            enable_posix_shm: input.enable_posix_shm,
         })
     }
 }
@@ -369,6 +386,8 @@ struct InputConfig {
     pub env: InputConfigEnv,
     #[serde(default)]
     pub app: Vec<InputConfigApp>,
+    #[serde(default)]
+    pub feature: InputConfigFeature,
 }
 
 #[derive(Deserialize, Debug)]
@@ -486,6 +505,24 @@ struct InputConfigApp {
     pub entry_points: Vec<String>,
     #[serde(default)]
     pub mount: Vec<InputConfigMount>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct InputConfigFeature {
+    #[serde(default)]
+    pub pkru: u32,
+    #[serde(default)]
+    pub enable_posix_shm: bool,
+}
+
+impl Default for InputConfigFeature {
+    fn default() -> InputConfigFeature {
+        InputConfigFeature {
+            pkru: 0,
+            enable_posix_shm: false,
+        }
+    }
 }
 
 #[repr(C)]

--- a/src/libos/src/vm/vm_manager.rs
+++ b/src/libos/src/vm/vm_manager.rs
@@ -852,14 +852,15 @@ impl InternalVMManager {
         new_chunk
     }
 
+    // The left chunk is an existing chunk, the right chunk is a newly-created chunk
     fn merge_two_single_vma_chunks(&mut self, lhs: &ChunkRef, rhs: &ChunkRef) -> ChunkRef {
         let mut new_vma = {
             let lhs_vma = lhs.get_vma_for_single_vma_chunk();
             let rhs_vma = rhs.get_vma_for_single_vma_chunk();
             debug_assert_eq!(lhs_vma.end(), rhs_vma.start());
 
-            let mut new_vma = rhs_vma.clone();
-            new_vma.set_start(lhs_vma.start());
+            let mut new_vma = lhs_vma.clone();
+            new_vma.set_end(rhs_vma.end());
             new_vma
         };
 

--- a/src/libos/src/vm/vm_manager.rs
+++ b/src/libos/src/vm/vm_manager.rs
@@ -9,6 +9,7 @@ use super::vm_area::{VMAccess, VMArea};
 use super::vm_chunk_manager::ChunkManager;
 use super::vm_perms::VMPerms;
 use super::vm_util::*;
+use crate::config::LIBOS_CONFIG;
 use crate::ipc::SYSTEM_V_SHM_MANAGER;
 use crate::process::{ThreadRef, ThreadStatus};
 
@@ -88,7 +89,7 @@ impl VMManager {
     }
 
     pub fn mmap(&self, options: &VMMapOptions) -> Result<usize> {
-        if options.is_shared() {
+        if LIBOS_CONFIG.feature.enable_posix_shm && options.is_shared() {
             let res = self.internal().mmap_shared_chunk(options);
             match res {
                 Ok(addr) => {
@@ -694,7 +695,7 @@ impl InternalVMManager {
             }
         };
 
-        if chunk.is_shared() {
+        if LIBOS_CONFIG.feature.enable_posix_shm && chunk.is_shared() {
             trace!(
                 "munmap_shared_chunk, chunk_range = {:?}, munmap_range = {:?}",
                 chunk.range(),
@@ -875,7 +876,7 @@ impl InternalVMManager {
         new_perms: VMPerms,
     ) -> Result<()> {
         debug_assert!(chunk.range().is_superset_of(&protect_range));
-        if chunk.is_shared() {
+        if LIBOS_CONFIG.feature.enable_posix_shm && chunk.is_shared() {
             trace!(
                 "mprotect_shared_chunk, chunk_range: {:?}, mprotect_range = {:?}",
                 chunk.range(),

--- a/test/Occlum.json
+++ b/test/Occlum.json
@@ -39,8 +39,11 @@
         "ext_prod_id": {
             "high": "0x0",
             "low": "0x0"
-        },
-        "pkru": 0
+        }
+    },
+    "feature": {
+        "pkru": 0,
+        "enable_posix_shm": true
     },
     "mount": [
         {


### PR DESCRIPTION
This PR includes:

1. A new configurable field "feature" is added in Occlum.json. Two features are now supported: "pkru" and "enable_posix_shm".
2. Minor improvement in shared chunk expansion in shm: Add current process to the shared set when there is a `NeedExpand` for two chunks.
3. Enable all features on hw ci for EDMM.