### PR TITLE
Modify copybom and add -inc parameter supports the output of modified file path to .path_log files

### DIFF
--- a/tools/copy_bom/README.md
+++ b/tools/copy_bom/README.md
@@ -27,6 +27,7 @@ All dependencies will be copied to the corresponding directory in root directory
 
 ### options
 - dry run mode: pass an option `--dry-run` to `copy_bom` will enable dry run mode. Dry run mode will output all file oprations in log but does not do real oprations. It is useul to check whether `copy_bom` performs as expected before doing real operations.
+- inc mode: pass an option `--inc` to `copy_bom` will enable inc mode. Inc mode will generate an additional file containing the file path of all the copies in rsync. The default path of the generated file is the path of `<root-dir>` plus ".log_path", which can also be specified by `--log-path`.
 
 ### flags
 - -i, --include-dir: This flag is used to indicate which directory to find included bom files. This flag can be set multiple times. If the `include-dir` is set as a relative path, it is a path relative to the current path where you run the `copy_bom` command. 

--- a/tools/copy_bom/src/main.rs
+++ b/tools/copy_bom/src/main.rs
@@ -31,6 +31,12 @@ struct CopyBomOption {
     /// Set the paths where to find included bom files
     #[structopt(long = "include-dir")]
     included_dirs: Vec<String>,
+    /// Flag for --inc option
+    #[structopt(long = "inc")]
+    inc: bool,
+    /// Set the paths under where to log files
+    #[structopt(long = "log-path")]
+    log_path: Option<String>,
 }
 
 impl CopyBomOption {
@@ -40,7 +46,10 @@ impl CopyBomOption {
             root_dir,
             dry_run,
             included_dirs,
+            inc,
+            log_path
         } = self;
+        util::set_log_path(log_path.clone(), root_dir.clone(), *inc);
         let image = Bom::from_yaml_file(bom_file);
         image.manage_top_bom(bom_file, root_dir, *dry_run, included_dirs);
     }

--- a/tools/occlum
+++ b/tools/occlum
@@ -382,6 +382,7 @@ cmd_build() {
     pal_lib=libocclum-pal.so
     libos_lib=libocclum-libos.so
     BUILDIN_IMAGE_KEY=false
+    INCREMENTAL_BUILD=false
 
     while [ -n "$1" ]; do
         case "$1" in
@@ -392,6 +393,7 @@ cmd_build() {
         --image-key)    [ -n "$2" ] && SECURE_IMAGE_KEY=$2 ; shift 2 || exit_error "empty secure image key path"   ;;
         --buildin-image-key)  BUILDIN_IMAGE_KEY=true ; shift ;;
         --force | -f)   MAKE_OPTION="clean" ; shift ;;
+        --inc)          INCREMENTAL_BUILD=true ; shift ;;
         *) exit_error "Unknown option: $1" ;;
         esac
     done
@@ -456,7 +458,7 @@ cmd_build() {
     occlum_version=$occlum_version libos_lib=$libos_lib INSTANCE_IS_FOR_EDMM_PLATFORM=$INSTANCE_IS_FOR_EDMM_PLATFORM \
     ENCLAVE_SIGN_KEY=$ENCLAVE_SIGN_KEY ENCLAVE_SIGN_TOOL=$ENCLAVE_SIGN_TOOL \
     SECURE_IMAGE_KEY=$SECURE_IMAGE_KEY BUILDIN_IMAGE_KEY=$BUILDIN_IMAGE_KEY \
-    make -f $build_makefile --no-builtin-rules
+    make -f $build_makefile INCREMENTAL_BUILD=$INCREMENTAL_BUILD
 
     cd "$instance_dir"
     echo "built" > $status_file


### PR DESCRIPTION
# notice
modified gitmodules, deps/sefs should support --inc when zip
use make submodule OCCLUM_GIT_OPTIONS="--remote deps/sefs" to make

# usage:
occlum new instance && cd instance
copybom ...
occlum build

change source code or other files

cd instance
copybom ... --inc
occlum build --inc