### PR TITLE
Implement System V Semaphore mechanism for Occlum

### DIFF
--- a/src/libos/src/events/waiter_queue.rs
+++ b/src/libos/src/events/waiter_queue.rs
@@ -46,6 +46,11 @@ impl<Sync: Synchronizer> WaiterQueue<Sync> {
         self.count.load(Ordering::Relaxed) == 0
     }
 
+    /// Returns the number of waiters in the queue.
+    pub fn len(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
     /// Reset a waiter and enqueue it.
     ///
     /// It is allowed to enqueue a waiter more than once before it is dequeued.

--- a/src/libos/src/ipc/mod.rs
+++ b/src/libos/src/ipc/mod.rs
@@ -1,7 +1,11 @@
 use super::*;
 
+mod sem;
 mod shm;
 mod syscalls;
 
+pub use self::sem::{sembuf_t, SYSTEM_V_SEM_MANAGER};
 pub use self::shm::{key_t, shmids_t, SYSTEM_V_SHM_MANAGER};
-pub use self::syscalls::{do_shmat, do_shmctl, do_shmdt, do_shmget};
+pub use self::syscalls::{
+    do_semctl, do_semget, do_semop, do_semtimedop, do_shmat, do_shmctl, do_shmdt, do_shmget,
+};

--- a/src/libos/src/ipc/sem.rs
+++ b/src/libos/src/ipc/sem.rs
@@ -1,0 +1,941 @@
+use super::*;
+
+use crate::events::{Observer, Waiter, WaiterQueue};
+use crate::process::{do_getegid, do_geteuid, gid_t, pid_t, uid_t, ThreadRef};
+use crate::time::{do_gettimeofday, time_t};
+use crate::util::mem_util::from_user;
+use alloc::vec::Vec;
+use bitflags::bitflags;
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, Ordering};
+use intrusive_collections::LinkedList;
+use std::cmp::Ordering as CmpOrdering;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::time::Duration;
+use std::{cmp, time};
+
+#[allow(non_camel_case_types)]
+pub type key_t = u32;
+pub type SemId = u32;
+pub type CmdId = u32;
+
+const IPC_PRIVATE: key_t = 0;
+
+// Maximum number of semaphore sets
+const SEMMNI: SemId = 128;
+// Maximum semaphores per set
+const SEMMSL: usize = 250;
+// Maximum semaphores system-wide
+const SEMMNS: usize = SEMMNI as usize * SEMMSL;
+// Maximum operations per semop call
+const SEMOPM: usize = 32;
+// Maximum semaphore value
+const SEMVMX: usize = 32767;
+
+const IPC_RMID: CmdId = 0; // Remove semaphore set
+const IPC_SET: CmdId = 1; // Set semaphore set parameters
+const IPC_STAT: CmdId = 2; // Get semaphore set status
+const IPC_INFO: CmdId = 3; // Get system-wide semaphore information
+
+// Semaphore operation command constants (following System V specifications)
+const SEM_GETPID: CmdId = 11; // Get PID of last operation
+const SEM_GETVAL: CmdId = 12; // Get semaphore value
+const SEM_GETALL: CmdId = 13; // Get all semaphore values in set
+const SEM_GETNCNT: CmdId = 14; // Get count of processes waiting for value > current
+const SEM_GETZCNT: CmdId = 15; // Get count of processes waiting for value = 0
+const SEM_SETVAL: CmdId = 16; // Set semaphore value
+const SEM_SETALL: CmdId = 17; // Set all semaphore values in set
+const SEM_STAT: CmdId = 18; // Get status by semid
+const SEM_INFO: CmdId = 19; // Get extended semaphore information
+const SEM_UNDO: CmdId = 20; // Undo operations for current process
+
+bitflags! {
+    pub struct SemFlags: u32 {
+        // IPC operation flags
+        const IPC_CREAT = 0o1000;    // Create if not exists
+        const IPC_EXCL = 0o2000;     // Fail if exists (with IPC_CREAT)
+        const IPC_NOWAIT = 0o4000;   // Non-blocking mode
+
+        // Semaphore-specific flags
+        const SEM_UNDO = 0o10000;    // Auto-undo operations on process exit
+
+        // Permission flags
+        const S_IRUSR = 0o400;       // Owner read permission
+        const S_IWUSR = 0o200;       // Owner write permission
+        const S_IXUSR = 0o100;       // Owner execute permission
+
+        const S_IRGRP = 0o040;       // Group read permission
+        const S_IWGRP = 0o020;       // Group write permission
+        const S_IXGRP = 0o010;       // Group execute permission
+
+        const S_IROTH = 0o004;       // Others read permission
+        const S_IWOTH = 0o002;       // Others write permission
+        const S_IXOTH = 0o001;       // Others execute permission
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+#[repr(C)]
+pub struct semids_t {
+    sem_perm: ipc_perm_t,
+    sem_otime: time_t,
+    sem_otime_high: time_t,
+    sem_ctime: time_t,
+    sem_ctime_high: time_t,
+    sem_nsems: u64,
+    unused1: u64,
+    unused2: u64,
+}
+
+/// Structure for storing semaphore system limits (used with IPC_INFO)
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct seminfo_t {
+    semmap: u32, // Number of entries in semaphore map
+    semmni: u32, // Maximum number of semaphore sets
+    semmns: u32, // Maximum number of semaphores in system
+    semmnu: u32, // System-wide maximum number of undo structures
+    semmsl: u32, // Maximum number of semaphores per set
+    semopm: u32, // Maximum number of operations per semop call
+    semume: u32, // Maximum number of undo entries per process
+    semusz: u32, // Size in bytes of undo structure
+    semvmx: u32, // Maximum semaphore value
+    semaem: u32, // Adjust on exit max value
+}
+
+/// Structure for extended semaphore system information (used with SEM_INFO)
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct seminfo_ext_t {
+    sem_info: seminfo_t, // Basic limit information
+    semusz: u32,         // Size of sem_undo structure
+    semaem: u32,         // Max adjust on exit value
+    sem_nsems: u32,      // Current number of semaphores in system
+    sem_nsets: u32,      // Current number of semaphore sets in system
+    sem_largest_id: u32, // Largest semaphore set identifier
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct ipc_perm_t {
+    key: key_t,
+    uid: uid_t,
+    gid: gid_t,
+    cuid: uid_t,
+    cgid: gid_t,
+    mode: u16,
+    pad1: u16,
+    seq: u16,
+    pad2: u16,
+    unused1: u64,
+    unused2: u64,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+#[repr(C)]
+pub struct sembuf_t {
+    sem_num: u16, // Semaphore number
+    sem_op: i16,  // Operation to perform
+    sem_flg: i16, // Operation flags
+}
+
+#[derive(Debug, Clone)]
+struct SemUndoOp {
+    semid: SemId,
+    sem_num: usize,
+    op: i32,
+}
+
+struct Semaphore {
+    count: i32,
+    waiter_zero: HashSet<pid_t>,    // Processes waiting for count = 0
+    waiter_acquire: HashSet<pid_t>, // Processes waiting to acquire (count > 0)
+    last_pid: pid_t,                // PID of last process that modified this semaphore
+}
+
+impl Semaphore {
+    fn new(initial_value: i32) -> Self {
+        Semaphore {
+            count: initial_value,
+            waiter_zero: HashSet::new(),
+            waiter_acquire: HashSet::new(),
+            last_pid: current!().process().pid(),
+        }
+    }
+
+    /// Checks if an operation can proceed immediately
+    /// Returns true if operation can complete, false if process needs to wait
+    fn check_op(&mut self, op: i32, pid: pid_t) -> bool {
+        match op.cmp(&0) {
+            // Positive operation: always allowed (increments semaphore)
+            CmpOrdering::Greater => true,
+
+            // Zero operation: wait if count > 0
+            CmpOrdering::Equal => {
+                if self.count > 0 {
+                    self.waiter_zero.insert(pid);
+                }
+                self.count == 0
+            }
+
+            // Negative operation: wait if insufficient count
+            CmpOrdering::Less => {
+                if self.count + op >= 0 {
+                    true
+                } else {
+                    self.waiter_acquire.insert(pid);
+                    false
+                }
+            }
+        }
+    }
+
+    /// Executes the semaphore operation and updates waiter sets
+    fn do_op(&mut self, op: i32, pid: pid_t) {
+        self.count += op;
+
+        // Remove process from wait lists since operation completed
+        if op == 0 {
+            self.waiter_zero.remove(&pid);
+        } else if op < 0 {
+            self.waiter_acquire.remove(&pid);
+        }
+    }
+
+    /// Returns number of processes waiting for count > current value
+    fn get_ncnt(&self) -> usize {
+        self.waiter_acquire.len()
+    }
+
+    /// Returns number of processes waiting for count = 0
+    fn get_zcnt(&self) -> usize {
+        self.waiter_zero.len()
+    }
+}
+
+struct SemSet {
+    semid: SemId,
+    nsems: usize,            // Number of semaphores in this set
+    perm: Mutex<ipc_perm_t>, // Permission structure
+    sem_otime: AtomicI64,    // Last operation time
+    sem_ctime: AtomicI64,    // Creation/modification time
+
+    sems: Mutex<Vec<Semaphore>>,          // The semaphores in this set
+    attached_pids: Mutex<HashSet<pid_t>>, // Processes attached to this set
+    waiter_queue: Mutex<WaiterQueue>,     // Queue for waiting processes
+
+    is_removed: AtomicBool, // Set to true when semaphore set is removed
+    marked_for_removal: AtomicBool, // Set when removal is requested but processes are still attached
+}
+
+impl SemSet {
+    /// Creates a new semaphore set
+    fn new(semid: SemId, key: key_t, nsems: usize, mode: u16) -> Result<Self> {
+        info!(
+            "New Semset Created: semid: {}, key: {}, nsems: {}, mode: {:o}",
+            semid, key, nsems, mode
+        );
+
+        // Validate number of semaphores
+        if nsems == 0 || nsems > SEMMSL {
+            return_errno!(EINVAL, "invalid number of semaphores");
+        }
+
+        // Initialize semaphores with value 0
+        let sems = (0..nsems).map(|_| Semaphore::new(0)).collect();
+
+        Ok(SemSet {
+            semid,
+            nsems,
+            perm: Mutex::new(ipc_perm_t {
+                key,
+                uid: 0,
+                gid: 0,
+                cuid: 0,
+                cgid: 0,
+                mode,
+                pad1: 0,
+                seq: 0,
+                pad2: 0,
+                unused1: 0,
+                unused2: 0,
+            }),
+            sem_otime: AtomicI64::new(0),
+            sem_ctime: AtomicI64::new(SemManager::current_time()),
+            sems: Mutex::new(sems),
+            attached_pids: Mutex::new(HashSet::new()),
+            waiter_queue: Mutex::new(WaiterQueue::new()),
+            is_removed: AtomicBool::new(false),
+            marked_for_removal: AtomicBool::new(false),
+        })
+    }
+
+    /// Marks semaphore set as removed and wakes all waiting processes
+    fn mark_removed_and_wake(&self) {
+        self.is_removed.store(true, Ordering::Relaxed);
+        let mut waiter_queue = self.waiter_queue.lock();
+        waiter_queue.dequeue_and_wake_all();
+    }
+
+    fn get_key(&self) -> key_t {
+        let perm = self.perm.lock();
+        perm.key
+    }
+
+    /// Updates permission structure and modification time
+    fn set_perm(&self, perm: &ipc_perm_t) {
+        let mut current_perm = self.perm.lock();
+        *current_perm = *perm;
+        self.sem_ctime
+            .store(SemManager::current_time(), Ordering::Relaxed);
+    }
+
+    fn get_perm(&self) -> ipc_perm_t {
+        let perm = self.perm.lock();
+        *perm
+    }
+
+    /// Records that a process is using this semaphore set
+    fn attach_pid(&self, pid: pid_t) {
+        let mut pids = self.attached_pids.lock();
+        pids.insert(pid);
+    }
+
+    /// Removes a process from the attached list
+    fn detach_pid(&self, pid: &pid_t) {
+        let mut pids = self.attached_pids.lock();
+        pids.remove(pid);
+    }
+
+    /// Executes a series of semaphore operations
+    fn do_semop(&self, sops: &[sembuf_t], mut timeout: Option<Duration>) -> Result<()> {
+        let pid = current!().process().pid();
+        let waiter = Waiter::new();
+
+        loop {
+            // Check if semaphore set was removed
+            if self.is_removed.load(Ordering::Relaxed) {
+                return_errno!(EIDRM, "semaphore set removed");
+            }
+
+            let mut sems = self.sems.lock();
+            let mut all_ops_can_proceed = true;
+
+            // First pass: check if all operations can complete
+            for sop in sops {
+                let sem_num = sop.sem_num as usize;
+
+                // Validate semaphore number
+                if sem_num >= self.nsems {
+                    return_errno!(EFBIG, "semaphore number out of range");
+                }
+
+                // Check if operation can proceed
+                if !sems[sem_num].check_op(sop.sem_op as i32, pid) {
+                    all_ops_can_proceed = false;
+
+                    // Fail immediately if NOWAIT flag is set
+                    let flags = SemFlags::from_bits_truncate(sop.sem_flg as u32);
+                    if flags.contains(SemFlags::IPC_NOWAIT) {
+                        return_errno!(EAGAIN, "semaphore count not zero");
+                    }
+                }
+            }
+
+            let mut waiter_queue = self.waiter_queue.lock();
+
+            // Execute operations if all can proceed
+            if all_ops_can_proceed {
+                let mut undo_ops = Vec::new();
+
+                // Apply all operations
+                for sop in sops {
+                    let sem_num = sop.sem_num as usize;
+                    let sem = &mut sems[sem_num];
+                    let op = sop.sem_op as i32;
+
+                    sem.do_op(op, pid);
+                    sem.last_pid = pid;
+
+                    // Record undo operations if needed
+                    let flags = SemFlags::from_bits_truncate(sop.sem_flg as u32);
+                    if flags.contains(SemFlags::SEM_UNDO) && op != 0 {
+                        undo_ops.push(SemUndoOp {
+                            semid: self.semid,
+                            sem_num,
+                            op: -op,
+                        });
+                    }
+                }
+
+                // Register undo operations with manager
+                if !undo_ops.is_empty() {
+                    SYSTEM_V_SEM_MANAGER.add_undo_ops(pid, undo_ops);
+                }
+
+                // Update operation time and wake waiting processes
+                self.sem_otime
+                    .store(SemManager::current_time(), Ordering::Relaxed);
+                waiter_queue.dequeue_and_wake_all();
+                return Ok(());
+            }
+
+            // Operations can't proceed - add to wait queue and block
+            waiter_queue.reset_and_enqueue(&waiter);
+            drop(sems);
+            drop(waiter_queue);
+
+            // Wait for notification or timeout
+            match waiter.wait_mut(timeout.as_mut()) {
+                Ok(()) => continue,
+                Err(e) if e.errno() == Errno::ETIMEDOUT => {
+                    return_errno!(ETIMEDOUT, "semaphore operation timed out");
+                }
+                // Handle signal interrupt
+                Err(e) if e.errno() == Errno::EINTR => {
+                    return_errno!(EINTR, "semaphore operation interrupted by signal");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Retrieves the current value of a specific semaphore
+    fn getval(&self, sem_num: usize) -> Result<i32> {
+        if self.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+        if sem_num >= self.nsems {
+            return_errno!(ERANGE, "semaphore number out of range");
+        }
+        let sems = self.sems.lock();
+        Ok(sems[sem_num].count)
+    }
+
+    /// Sets the value of a specific semaphore
+    fn setval(&self, sem_num: usize, count: i32) -> Result<()> {
+        if self.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+        let mut sems = self.sems.lock();
+
+        // Validate parameters
+        if sem_num >= self.nsems {
+            return_errno!(ERANGE, "semaphore number out of range");
+        }
+        if count < 0 {
+            return_errno!(ERANGE, "semaphore count cannot be negative");
+        }
+        if count > SEMVMX as i32 {
+            return_errno!(ERANGE, "semaphore count exceeds maximum value");
+        }
+
+        // Update value and modification time
+        sems[sem_num].count = count;
+        self.sem_ctime
+            .store(SemManager::current_time(), Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Returns number of processes waiting for this semaphore's value to increase
+    fn get_ncnt(&self, sem_num: usize) -> Result<usize> {
+        if self.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+        if sem_num >= self.nsems {
+            return_errno!(ERANGE, "semaphore number out of range");
+        }
+        let sems = self.sems.lock();
+        Ok(sems[sem_num].get_ncnt())
+    }
+
+    /// Returns number of processes waiting for this semaphore's value to reach zero
+    fn get_zcnt(&self, sem_num: usize) -> Result<usize> {
+        if self.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+        if sem_num >= self.nsems {
+            return_errno!(ERANGE, "semaphore number out of range");
+        }
+        let sems = self.sems.lock();
+        Ok(sems[sem_num].get_zcnt())
+    }
+
+    /// Applies an undo operation to a semaphore
+    fn undo_op(&self, sem_num: usize, op: i32) -> Result<()> {
+        if self.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+        let mut sems = self.sems.lock();
+        if sem_num >= self.nsems {
+            return_errno!(ERANGE, "semaphore number out of range");
+        }
+
+        // Apply the undo operation
+        let sem = &mut sems[sem_num];
+        sem.count += op;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SemIdManager {
+    used_id: HashSet<SemId>, // Track allocated semaphore IDs
+    free_num: u32,           // Number of available IDs
+    last_alloc_id: SemId,    // Last allocated ID (for efficient allocation)
+}
+
+impl SemIdManager {
+    fn new() -> Self {
+        SemIdManager {
+            used_id: HashSet::new(),
+            free_num: SEMMNI as u32,
+            last_alloc_id: SEMMNI - 1,
+        }
+    }
+
+    /// Allocates a new unique semaphore ID
+    fn get_new_semid(&mut self) -> Result<SemId> {
+        // Check if maximum sets reached
+        if self.free_num == 0 {
+            return_errno!(ENOSPC, "all possible semaphore IDs have been taken");
+        }
+        self.free_num -= 1;
+
+        // Find next available ID (wrapping around if necessary)
+        let mut id = self.last_alloc_id + 1;
+        loop {
+            if id == SEMMNI {
+                id = 0;
+            }
+            if !self.used_id.contains(&id) {
+                break;
+            }
+            id += 1;
+        }
+
+        self.used_id.insert(id);
+        self.last_alloc_id = id;
+        Ok(id)
+    }
+
+    /// Releases a semaphore ID back to the pool
+    fn free_semid(&mut self, shmid: &SemId) -> Result<()> {
+        self.free_num += 1;
+        self.used_id.remove(shmid);
+        Ok(())
+    }
+}
+
+lazy_static! {
+    pub static ref SYSTEM_V_SEM_MANAGER: SemManager = SemManager::new();
+}
+
+pub struct SemManager {
+    sem_sets: RwLock<HashMap<SemId, Arc<SemSet>>>, // All active semaphore sets
+    semid_manager: RwLock<SemIdManager>,           // Manages semaphore ID allocation
+    undo_logs: RwLock<HashMap<pid_t, Vec<SemUndoOp>>>, // Tracks undo operations per process
+}
+
+impl SemManager {
+    fn new() -> Self {
+        SemManager {
+            sem_sets: RwLock::new(HashMap::new()),
+            semid_manager: RwLock::new(SemIdManager::new()),
+            undo_logs: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Gets current time for timestamping operations
+    fn current_time() -> time_t {
+        do_gettimeofday().sec()
+    }
+
+    /// Allocates a new semaphore ID through the ID manager
+    fn get_new_semid(&self) -> Result<SemId> {
+        let mut semid_manager = self.semid_manager.write().unwrap();
+        semid_manager.get_new_semid()
+    }
+
+    /// Retrieves a semaphore set by ID
+    fn get_semset(&self, semid: &SemId) -> Result<Arc<SemSet>> {
+        let sem_sets = self.sem_sets.read().unwrap();
+        let semset = sem_sets
+            .get(semid)
+            .ok_or_else(|| errno!(EINVAL, "invalid semid"))?
+            .clone();
+        Ok(semset)
+    }
+
+    /// Releases a semaphore ID
+    fn free_semid(&self, semid: &SemId) -> Result<()> {
+        let mut semid_manager = self.semid_manager.write().unwrap();
+        semid_manager.free_semid(semid)
+    }
+
+    /// Adds undo operations for a process
+    fn add_undo_ops(&self, pid: pid_t, ops: Vec<SemUndoOp>) {
+        let mut undo_logs = self.undo_logs.write().unwrap();
+        let entry = undo_logs.entry(pid).or_insert_with(Vec::new);
+        entry.extend(ops);
+    }
+
+    /// Applies all pending undo operations for a process
+    fn perform_undo_ops(&self, pid: pid_t) {
+        let mut undo_logs = self.undo_logs.write().unwrap();
+        if let Some(ops) = undo_logs.remove(&pid) {
+            for op in ops {
+                if let Ok(sem_set) = self.get_semset(&op.semid) {
+                    let _ = sem_set.undo_op(op.sem_num, op.op);
+                }
+            }
+        }
+    }
+
+    /// Returns total number of semaphores across all sets
+    fn get_total_semaphores(&self) -> usize {
+        let sem_sets = self.sem_sets.read().unwrap();
+        sem_sets.values().map(|set| set.nsems).sum()
+    }
+
+    /// Returns current number of semaphore sets
+    fn get_semset_count(&self) -> usize {
+        let sem_sets = self.sem_sets.read().unwrap();
+        sem_sets.len()
+    }
+
+    /// Returns the largest currently allocated semaphore ID
+    fn get_largest_semid(&self) -> SemId {
+        let sem_sets = self.sem_sets.read().unwrap();
+        sem_sets.keys().max().copied().unwrap_or(0)
+    }
+
+    /// Implements semget: creates or retrieves a semaphore set
+    pub fn do_semget(&self, key: key_t, nsems: usize, semflg: SemFlags) -> Result<SemId> {
+        let mut sem_sets = self.sem_sets.write().unwrap();
+
+        let mode = semflg.bits() as u16 & 0o777;
+        let semid = if key == IPC_PRIVATE {
+            // Create private semaphore set (always new)
+            let semid = self.get_new_semid()?;
+            let sem_set = Arc::new(SemSet::new(semid, key, nsems, mode)?);
+            sem_sets.insert(sem_set.semid, sem_set);
+            semid
+        } else {
+            // Look for existing set with this key
+            let sem_set = sem_sets.values().find(|&set| set.get_key() == key);
+
+            match sem_set {
+                Some(set) => {
+                    // Handle existing set
+                    if semflg.contains(SemFlags::IPC_CREAT) && semflg.contains(SemFlags::IPC_EXCL) {
+                        return_errno!(EEXIST, "semaphore set already exists");
+                    }
+                    if nsems > 0 && nsems != set.nsems {
+                        return_errno!(EINVAL, "nsems does not match existing set");
+                    }
+                    set.semid
+                }
+                None => {
+                    // No existing set - create if requested
+                    if !semflg.contains(SemFlags::IPC_CREAT) {
+                        return_errno!(ENOENT, "no semaphore set exists for key");
+                    }
+                    if nsems == 0 || nsems > SEMMSL {
+                        return_errno!(EINVAL, "invalid nsems");
+                    }
+
+                    // Create new semaphore set
+                    let semid = self.get_new_semid()?;
+                    let sem_set = Arc::new(SemSet::new(semid, key, nsems, mode)?);
+                    sem_sets.insert(sem_set.semid, sem_set);
+                    semid
+                }
+            }
+        };
+        Ok(semid)
+    }
+
+    /// Implements semop: performs semaphore operations
+    pub fn do_semop(
+        &self,
+        semid: SemId,
+        sops_ptr: *const sembuf_t,
+        nsops: usize,
+        mut timeout: Option<Duration>,
+    ) -> Result<()> {
+        // Validate number of operations
+        if nsops == 0 || nsops > SEMOPM {
+            return_errno!(E2BIG, "too many operations");
+        }
+
+        // Copy operations from user space
+        let sops = from_user::make_slice(sops_ptr, nsops)?;
+        let pid = current!().process().pid();
+
+        // Get semaphore set and verify it exists
+        let sem_set = self.get_semset(&semid)?;
+
+        // Check for race condition (set removed after getting reference)
+        if sem_set.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+
+        // Attach process to the set and perform operations
+        sem_set.attach_pid(pid);
+        let result = sem_set.do_semop(&sops, timeout);
+
+        // Detach process after operations complete
+        sem_set.detach_pid(&pid);
+        result
+    }
+
+    /// Implements semctl: performs control operations on semaphores
+    pub fn do_semctl(&self, semid: SemId, semnum: usize, cmd: CmdId, arg: usize) -> Result<usize> {
+        info!(
+            "do_semctl: semid: {:?}, semnum: {:?}, cmd: {:?}, arg: {:?}",
+            semid, semnum, cmd, arg
+        );
+
+        // Handle SEM_UNDO command (clear undo operations)
+        if cmd == SEM_UNDO {
+            let pid = current!().process().pid();
+            let mut undo_logs = self.undo_logs.write().unwrap();
+            undo_logs.remove(&pid);
+            return Ok(0);
+        }
+
+        // Handle IPC_RMID (remove semaphore set)
+        if cmd == IPC_RMID {
+            let sem_set = self.get_semset(&semid)?;
+            // Mark as removed and wake waiting processes
+            sem_set.mark_removed_and_wake();
+
+            sem_set.marked_for_removal.store(true, Ordering::Relaxed);
+
+            // Remove immediately if no processes are attached
+            let is_empty = {
+                let pids = sem_set.attached_pids.lock();
+                pids.is_empty()
+            };
+            if is_empty {
+                self.free_semid(&semid)?;
+                let mut sem_sets = self.sem_sets.write().unwrap();
+                sem_sets.remove(&semid);
+            }
+            return Ok(0);
+        }
+
+        // Handle commands that don't require a specific semaphore set
+        match cmd {
+            IPC_INFO => {
+                // Fill system semaphore limits
+                let info_ptr = arg as *mut seminfo_t;
+                let info = unsafe {
+                    info_ptr
+                        .as_mut()
+                        .ok_or_else(|| errno!(EFAULT, "invalid pointer"))?
+                };
+
+                *info = seminfo_t {
+                    semmap: 0,
+                    semmni: SEMMNI,
+                    semmns: SEMMNS as u32,
+                    semmnu: 0,
+                    semmsl: SEMMSL as u32,
+                    semopm: SEMOPM as u32,
+                    semume: 0,
+                    semusz: 0,
+                    semvmx: SEMVMX as u32,
+                    semaem: 0,
+                };
+
+                return Ok(SEMMNI as usize);
+            }
+
+            SEM_INFO => {
+                // Fill extended semaphore information
+                let info_ptr = arg as *mut seminfo_ext_t;
+                let info = unsafe {
+                    info_ptr
+                        .as_mut()
+                        .ok_or_else(|| errno!(EFAULT, "invalid pointer"))?
+                };
+
+                // Base limit information
+                let base_info = seminfo_t {
+                    semmap: 0,
+                    semmni: SEMMNI,
+                    semmns: SEMMNS as u32,
+                    semmnu: 0,
+                    semmsl: SEMMSL as u32,
+                    semopm: SEMOPM as u32,
+                    semume: 0,
+                    semusz: 0,
+                    semvmx: SEMVMX as u32,
+                    semaem: 0,
+                };
+
+                // Current system status
+                *info = seminfo_ext_t {
+                    sem_info: base_info,
+                    semusz: 0,
+                    semaem: 0,
+                    sem_nsems: self.get_total_semaphores() as u32,
+                    sem_nsets: self.get_semset_count() as u32,
+                    sem_largest_id: self.get_largest_semid(),
+                };
+
+                return Ok(self.get_largest_semid() as usize);
+            }
+
+            _ => {} // Other commands require a semaphore set
+        }
+
+        // Get semaphore set for remaining commands
+        let sem_set = self.get_semset(&semid)?;
+
+        // Check if set was removed
+        if sem_set.is_removed.load(Ordering::Relaxed) {
+            return_errno!(EIDRM, "semaphore set removed");
+        }
+
+        // Handle set-specific commands
+        match cmd {
+            IPC_SET => {
+                // Update permission structure
+                let perm = arg as *const ipc_perm_t;
+                let perm = unsafe {
+                    perm.as_ref()
+                        .ok_or_else(|| errno!(EFAULT, "invalid perm"))?
+                };
+                sem_set.set_perm(perm);
+                Ok(0)
+            }
+            IPC_STAT => {
+                // Retrieve status information
+                let buf_ptr = arg as *mut semids_t;
+                let buf = unsafe {
+                    buf_ptr
+                        .as_mut()
+                        .ok_or_else(|| errno!(EFAULT, "invalid buf"))?
+                };
+                *buf = semids_t {
+                    sem_perm: sem_set.get_perm(),
+                    sem_otime: sem_set.sem_otime.load(Ordering::Relaxed),
+                    sem_otime_high: 0,
+                    sem_ctime: sem_set.sem_ctime.load(Ordering::Relaxed),
+                    sem_ctime_high: 0,
+                    sem_nsems: sem_set.nsems as u64,
+                    unused1: 0,
+                    unused2: 0,
+                };
+                Ok(0)
+            }
+            SEM_GETPID => {
+                // Get PID of last operation
+                if semnum >= sem_set.nsems {
+                    return_errno!(ERANGE, "semaphore number out of range");
+                }
+                let sems = sem_set.sems.lock();
+                Ok(sems[semnum].last_pid as usize)
+            }
+            SEM_GETVAL => {
+                // Get current semaphore value
+                let value = sem_set.getval(semnum)?;
+                Ok(value as usize)
+            }
+            SEM_GETALL => {
+                // Get all semaphore values in set
+                let vals_ptr = arg as *mut u16;
+                if vals_ptr.is_null() {
+                    return_errno!(EFAULT, "null pointer");
+                }
+
+                let vals = from_user::make_mut_slice(vals_ptr, sem_set.nsems)?;
+                for i in 0..sem_set.nsems {
+                    vals[i] = sem_set.getval(i)? as u16;
+                }
+                Ok(0)
+            }
+            SEM_GETNCNT => {
+                // Get count of processes waiting for higher value
+                let ncnt = sem_set.get_ncnt(semnum)?;
+                Ok(ncnt)
+            }
+            SEM_GETZCNT => {
+                // Get count of processes waiting for zero
+                let zcnt = sem_set.get_zcnt(semnum)?;
+                Ok(zcnt)
+            }
+            SEM_SETVAL => {
+                // Set individual semaphore value
+                let value = arg as i32;
+                sem_set.setval(semnum, value)?;
+                Ok(0)
+            }
+            SEM_SETALL => {
+                // Set all semaphore values in set
+                let vals_ptr = arg as *const u16;
+                if vals_ptr.is_null() {
+                    return_errno!(EFAULT, "null pointer");
+                }
+
+                let vals = from_user::make_slice(vals_ptr, sem_set.nsems)?;
+                for i in 0..sem_set.nsems {
+                    let value = vals[i] as i32;
+                    sem_set.setval(i, value)?;
+                }
+                Ok(0)
+            }
+            SEM_STAT => {
+                // Get status by semid
+                let buf_ptr = arg as *mut semids_t;
+                let buf = unsafe {
+                    buf_ptr
+                        .as_mut()
+                        .ok_or_else(|| errno!(EFAULT, "invalid buf"))?
+                };
+
+                *buf = semids_t {
+                    sem_perm: sem_set.get_perm(),
+                    sem_otime: sem_set.sem_otime.load(Ordering::Relaxed),
+                    sem_otime_high: 0,
+                    sem_ctime: sem_set.sem_ctime.load(Ordering::Relaxed),
+                    sem_ctime_high: 0,
+                    sem_nsems: sem_set.nsems as u64,
+                    unused1: 0,
+                    unused2: 0,
+                };
+                Ok(sem_set.semid as usize)
+            }
+            _ => return_errno!(EINVAL, "unsupported command"),
+        }
+    }
+
+    /// Cleans up semaphore resources when a process exits
+    pub fn detach_sem_when_process_exit(&self, thread: &ThreadRef) {
+        let pid = thread.process().pid();
+        // Apply any pending undo operations
+        self.perform_undo_ops(pid);
+
+        // Detach process from all semaphore sets
+        let mut sem_sets = self.sem_sets.write().unwrap();
+        for (_, sem_set) in sem_sets.iter_mut() {
+            sem_set.detach_pid(&pid);
+        }
+    }
+
+    /// Cleans up all semaphore resources on system exit
+    pub fn clean_when_libos_exit(&self) {
+        let mut sem_sets = self.sem_sets.write().unwrap();
+        for (semid, _) in sem_sets.drain() {
+            self.free_semid(&semid);
+        }
+    }
+}

--- a/src/libos/src/ipc/syscalls.rs
+++ b/src/libos/src/ipc/syscalls.rs
@@ -1,7 +1,10 @@
 use super::*;
 
+use crate::time::timespec_t;
+use std::time::Duration;
 use util::mem_util::from_user;
 
+use super::sem::{sembuf_t, semids_t, SemFlags, SemId, SYSTEM_V_SEM_MANAGER};
 use super::shm::{shmids_t, CmdId, ShmFlags, ShmId, SYSTEM_V_SHM_MANAGER};
 
 pub fn do_shmget(key: key_t, size: size_t, shmflg: i32) -> Result<isize> {
@@ -32,5 +35,56 @@ pub fn do_shmctl(shmid: i32, cmd: i32, buf_u: *mut shmids_t) -> Result<isize> {
         None
     };
     SYSTEM_V_SHM_MANAGER.do_shmctl(shmid as ShmId, cmd as CmdId, buf)?;
+    Ok(0)
+}
+
+pub fn do_semget(key: key_t, nsems: i32, semflg: i32) -> Result<isize> {
+    let semflg =
+        SemFlags::from_bits(semflg as u32).ok_or_else(|| errno!(EINVAL, "invalid flags"))?;
+    let semid = SYSTEM_V_SEM_MANAGER.do_semget(key, nsems as usize, semflg)?;
+    Ok(semid as isize)
+}
+
+pub fn do_semctl(semid: i32, semnum: i32, cmd: i32, arg: usize) -> Result<isize> {
+    let cmd = {
+        if cmd >= 256 {
+            cmd - 256
+        } else {
+            cmd
+        }
+    };
+
+    let ret = SYSTEM_V_SEM_MANAGER.do_semctl(semid as SemId, semnum as usize, cmd as CmdId, arg)?;
+    Ok(ret as isize)
+}
+
+pub fn do_semop(semid: i32, sops_ptr: *const sembuf_t, nsops: usize) -> Result<isize> {
+    if nsops == 0 {
+        return Ok(0);
+    }
+    let ret = SYSTEM_V_SEM_MANAGER.do_semop(semid as SemId, sops_ptr, nsops, None)?;
+    Ok(9)
+}
+
+pub fn do_semtimedop(
+    semid: i32,
+    sops_ptr: *const sembuf_t,
+    nsops: usize,
+    timeout_ptr: *const timespec_t,
+) -> Result<isize> {
+    if nsops == 0 {
+        return Ok(0);
+    }
+
+    let timeout: Option<Duration> = {
+        if timeout_ptr.is_null() {
+            None
+        } else {
+            let timeout = timespec_t::from_raw_ptr(timeout_ptr)?;
+            Some(timeout.as_duration())
+        }
+    };
+
+    SYSTEM_V_SEM_MANAGER.do_semop(semid as SemId, sops_ptr, nsops, timeout)?;
     Ok(0)
 }

--- a/src/libos/src/process/do_exit.rs
+++ b/src/libos/src/process/do_exit.rs
@@ -7,7 +7,7 @@ use super::do_vfork::{is_vforked_child_process, vfork_return_to_parent};
 use super::pgrp::clean_pgrp_when_exit;
 use super::process::{Process, ProcessFilter};
 use super::{table, ProcessRef, TermStatus, ThreadRef, ThreadStatus};
-use crate::ipc::SYSTEM_V_SHM_MANAGER;
+use crate::ipc::{SYSTEM_V_SEM_MANAGER, SYSTEM_V_SHM_MANAGER};
 use crate::prelude::*;
 use crate::signal::{KernelSignal, SigNum};
 use crate::syscall::CpuContext;
@@ -121,6 +121,8 @@ fn exit_process(thread: &ThreadRef, term_status: TermStatus) {
     // Clean used VM
     USER_SPACE_VM_MANAGER.free_chunks_when_exit(thread);
     SYSTEM_V_SHM_MANAGER.detach_shm_when_process_exit(thread);
+    // Clean used sem
+    SYSTEM_V_SEM_MANAGER.detach_sem_when_process_exit(thread);
 
     // The parent is the idle process
     if parent_inner.is_none() {

--- a/src/libos/src/syscall/mod.rs
+++ b/src/libos/src/syscall/mod.rs
@@ -39,7 +39,10 @@ use crate::fs::{
     Statfs,
 };
 use crate::interrupt::{do_handle_interrupt, sgx_interrupt_info_t};
-use crate::ipc::{do_shmat, do_shmctl, do_shmdt, do_shmget, key_t, shmids_t};
+use crate::ipc::{
+    do_semctl, do_semget, do_semop, do_semtimedop, do_shmat, do_shmctl, do_shmdt, do_shmget, key_t,
+    sembuf_t, shmids_t,
+};
 use crate::misc::{resource_t, rlimit_t, sysinfo_t, utsname_t, RandFlags};
 use crate::net::{
     do_accept, do_accept4, do_bind, do_connect, do_epoll_create, do_epoll_create1, do_epoll_ctl,
@@ -161,9 +164,9 @@ macro_rules! process_syscall_table_with_callback {
             (Wait4 = 61) => do_wait4(pid: i32, _exit_status: *mut i32, options: u32),
             (Kill = 62) => do_kill(pid: i32, sig: c_int),
             (Uname = 63) => do_uname(name: *mut utsname_t),
-            (Semget = 64) => handle_unsupported(),
-            (Semop = 65) => handle_unsupported(),
-            (Semctl = 66) => handle_unsupported(),
+            (Semget = 64) => do_semget(key: u32, nsems: i32, semflg: i32),
+            (Semop = 65) => do_semop(semid: i32, sops_ptr: *const sembuf_t, nsops: usize),
+            (Semctl = 66) => do_semctl(semid: i32, semnum: i32, cmd: i32, arg: usize),
             (Shmdt = 67) => do_shmdt(shmaddr: usize),
             (Msgget = 68) => handle_unsupported(),
             (Msgsnd = 69) => handle_unsupported(),
@@ -317,7 +320,7 @@ macro_rules! process_syscall_table_with_callback {
             (Getdents64 = 217) => do_getdents64(fd: FileDesc, buf: *mut u8, buf_size: usize),
             (SetTidAddress = 218) => do_set_tid_address(tidptr: *mut pid_t),
             (RestartSysCall = 219) => handle_unsupported(),
-            (Semtimedop = 220) => handle_unsupported(),
+            (Semtimedop = 220) => do_semtimedop(semid: i32, sops_ptr: *const sembuf_t, nsops: usize, timeout_ptr: *const timespec_t),
             (Fadvise64 = 221) => handle_unsupported(),
             (TimerCreate = 222) => handle_unsupported(),
             (TimerSettime = 223) => handle_unsupported(),

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ TESTS ?= env empty hello_world malloc mmap file fs_perms getpid spawn sched pipe
 	server server_epoll unix_socket cout hostfs cpuid rdtsc device sleep exit_group posix_flock \
 	ioctl fcntl eventfd emulate_syscall access signal sysinfo prctl rename procfs pselect sigsuspend \
 	wait spawn_attribute exec statfs random umask pgrp vfork mount flock utimes shm epoll brk posix_shm \
-	raw_socket
+	raw_socket sem
+
 # Benchmarks: need to be compiled and run by bench-% target
 BENCHES := spawn_and_exit_latency pipe_throughput unix_socket_throughput
 

--- a/test/sem/Makefile
+++ b/test/sem/Makefile
@@ -1,0 +1,5 @@
+include ../test_common.mk
+
+EXTRA_C_FLAGS :=
+EXTRA_LINK_FLAGS :=
+BIN_ARGS :=

--- a/test/sem/main.c
+++ b/test/sem/main.c
@@ -1,0 +1,548 @@
+#define _GNU_SOURCE
+#include <sys/ipc.h>
+#include <sys/sem.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <spawn.h>
+#include <unistd.h>
+#include <errno.h>
+#include "test.h"
+
+// ============================================================================
+// Global Definitions (Semaphore Test Specific)
+// ============================================================================
+
+// Permission macro (same as shm, ensures user read/write permissions)
+#define S_IRWUSER   (S_IRUSR | S_IWUSR)
+
+// Test type identifiers
+#define TEST_GET_SEMID_BY_KEY   0   // Get semid by key
+#define TEST_PROCESS_SYNC       1   // Inter-process semaphore synchronization
+#define TEST_IMMEDIATELY_RMSEM  2   // Verify immediate semaphore removal
+#define TEST_OPERATE_DESTOYED   3   // Operate on destroyed semaphore
+#define TEST_NO_RMSEM           4   // Do not remove semaphore (memory leak detection)
+
+// Number of parameters for each test case (child process argv length)
+#define TEST_GET_SEMID_BY_KEY_ARGC  5
+#define TEST_PROCESS_SYNC_ARGC     4
+#define TEST_OPERATE_DESTOYED_ARGC  5
+
+// General macro definitions
+#define ARG_BUF_SZ  64              // Parameter buffer size
+#define SEM_SET_SIZE 1              // Semaphore set size (using 1 semaphore)
+#define SEM_INIT_VAL 1              // Default initial semaphore value
+#define SUCCESS     1
+#define FAIL        (-1)
+
+const char prog_name[] = "/bin/sem";
+
+// ============================================================================
+// Helper Macros and Functions (Reusing shm test logic, adapted for semaphores)
+// ============================================================================
+
+// Log printing macro (includes file/line/function name for easier troubleshooting)
+#define INFO(fmt, ...)   do { \
+    printf("\t\t[SEM TEST] [file: %s, line: %d, func: %s] " fmt, \
+    __FILE__, __LINE__, __func__, ##__VA_ARGS__); \
+} while (0)
+
+// Spawn child process to execute test and check exit status
+// Returns SUCCESS if child test passes; FAIL if child test fails
+static int execute_in_child(char **const child_argv) {
+    int ret;
+    pid_t child_pid;
+    int child_status;
+
+    // Create child process
+    ret = posix_spawn(&child_pid, prog_name, NULL, NULL, (char **const)child_argv, NULL);
+    if (ret < 0) {
+        THROW_ERROR("posix_spawn() failed (errno: %d)", errno);
+    }
+
+    // Wait for child process to exit
+    ret = waitpid(child_pid, &child_status, 0);
+    if (ret < 0) {
+        THROW_ERROR("waitpid() failed (errno: %d)", errno);
+    }
+
+    // Check child process exit status (normal exit with code 0)
+    if (!WIFEXITED(child_status) || WEXITSTATUS(child_status) != 0) {
+        INFO("Child process test failed (exit code: %d)\n", WEXITSTATUS(child_status));
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+// ============================================================================
+// Core Semaphore Test Cases
+// ============================================================================
+
+/**
+ * Test 1: Create/get semid by key (basic functionality verification)
+ * Scenarios:
+ * 1. Get non-existent semaphore → should return ENOENT
+ * 2. Create new semaphore (IPC_CREAT|IPC_EXCL) → should successfully get semid
+ * 3. Get existing semaphore by key in same process → semid should match
+ * 4. Attempt to recreate with IPC_EXCL → should return EEXIST
+ * 5. Child process gets semaphore by key → semid should match parent's
+ */
+static int test_semget_semid_from_key(void) {
+    int ret, semid;
+    key_t key;
+    char *child_argv[TEST_GET_SEMID_BY_KEY_ARGC + 1]; // +1 for NULL terminator
+
+    // Generate random key (avoid conflict with existing semaphores)
+    srand(time(NULL));
+    key = random();
+    INFO("Test key: %d\n", key);
+
+    // Scenario 1: Get non-existent semaphore → expect ENOENT
+    ret = syscall(SYS_semget, key, SEM_SET_SIZE, S_IRWUSER);
+    if (ret != -1 || errno != ENOENT) {
+        INFO("semget() failed: expected ENOENT, actual ret=%d, errno=%d\n", ret, errno);
+        return FAIL;
+    }
+
+    // Scenario 2: Create new semaphore (IPC_CREAT|IPC_EXCL) → should succeed
+    semid = syscall(SYS_semget, key, SEM_SET_SIZE, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (semid < 0) {
+        THROW_ERROR("semget() create failed (errno: %d)", errno);
+    }
+    INFO("Created semid: %d\n", semid);
+
+    // Scenario 3: Set initial semaphore value (undefined after semget, needs explicit setting)
+    ret = syscall(SYS_semctl, semid, 0, SETVAL, SEM_INIT_VAL);
+    if (ret < 0) {
+        THROW_ERROR("semctl(SETVAL) failed (errno: %d)", errno);
+    }
+
+
+    // Scenario 4: Get existing semaphore in same process → verify semid and value match
+    ret = syscall(SYS_semget, key, SEM_SET_SIZE, S_IRWUSER);
+    if (ret < 0) {
+        THROW_ERROR("semget() get existing failed (errno: %d)", errno);
+    }
+    if (ret != semid) {
+        INFO("semid mismatch: expected %d, actual %d\n", semid, ret);
+        return FAIL;
+    }
+    ret = syscall(SYS_semctl, semid, 0, GETVAL);
+    if (ret != SEM_INIT_VAL) {
+        INFO("sem val mismatch: expected %d, actual %d\n", SEM_INIT_VAL, ret);
+        return FAIL;
+    }
+
+    // Scenario 5: Attempt to recreate with IPC_EXCL → expect EEXIST
+    ret = syscall(SYS_semget, key, SEM_SET_SIZE, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (ret != -1 || errno != EEXIST) {
+        INFO("semget() failed: expected EEXIST, actual ret=%d, errno=%d\n", ret, errno);
+        return FAIL;
+    }
+
+    // Scenario 6: Child process gets semid by key → verify consistency
+    // Initialize child process arguments (argv[0]=program name, argv[1]=test type, argv[2]=key, argv[3]=semid, argv[4]=initial value)
+    for (int i = 0; i < TEST_GET_SEMID_BY_KEY_ARGC; i++) {
+        child_argv[i] = (char *)malloc(ARG_BUF_SZ);
+        if (child_argv[i] == NULL) {
+            THROW_ERROR("malloc() failed for child argv");
+        }
+    }
+    snprintf(child_argv[0], ARG_BUF_SZ, "%s", prog_name);
+    snprintf(child_argv[1], ARG_BUF_SZ, "%d", TEST_GET_SEMID_BY_KEY);
+    snprintf(child_argv[2], ARG_BUF_SZ, "%d", key);
+    snprintf(child_argv[3], ARG_BUF_SZ, "%d", semid);
+    snprintf(child_argv[4], ARG_BUF_SZ, "%d", SEM_INIT_VAL);
+    child_argv[TEST_GET_SEMID_BY_KEY_ARGC] = NULL; // Terminator
+
+    // Execute child process test
+    if ((ret = execute_in_child(child_argv)) != SUCCESS) {
+        INFO("Child test (GET_SEMID_BY_KEY) failed\n");
+        return FAIL;
+    }
+
+    // Cleanup resources
+    for (int i = 0; i < TEST_GET_SEMID_BY_KEY_ARGC; i++) {
+        free(child_argv[i]);
+    }
+
+    // Delete semaphore
+    ret = syscall(SYS_semctl, semid, 0, IPC_RMID);
+    if (ret < 0) {
+        THROW_ERROR("semctl(IPC_RMID) failed (errno: %d)", errno);
+    }
+
+    INFO("Test semget_semid_from_key passed\n");
+    return SUCCESS;
+}
+
+/**
+ * Test 2: Inter-process semaphore synchronization (core functionality verification)
+ * Logic:
+ * 1. Parent process creates semaphore (initial value 1), performs P operation (value→0)
+ * 2. Child process performs V operation (value→1)
+ * 3. Parent process verifies semaphore value returns to 1 → synchronization works
+ */
+static int test_process_sync(void) {
+    int ret, semid;
+    int sem_val;
+    char *child_argv[TEST_PROCESS_SYNC_ARGC + 1];
+    // Semaphore operation structure (P operation: sem_op=-1, V operation: sem_op=1)
+    struct sembuf p_op = {0, -1, 0}; // sem_num=0 (first semaphore), sem_flg=0 (blocking)
+
+    // Step 1: Create anonymous semaphore (IPC_PRIVATE, visible only to parent and child)
+    semid = syscall(SYS_semget, IPC_PRIVATE, SEM_SET_SIZE, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (semid < 0) {
+        THROW_ERROR("semget() create private failed (errno: %d)", errno);
+    }
+
+    // Step 2: Set initial value to 1
+    ret = syscall(SYS_semctl, semid, 0, SETVAL, SEM_INIT_VAL);
+    if (ret < 0) {
+        THROW_ERROR("semctl(SETVAL) failed (errno: %d)", errno);
+    }
+
+    // Step 3: Parent performs P operation (value from 1→0)
+    ret = syscall(SYS_semop, semid, &p_op, 1); // 1=number of operations
+    if (ret < 0) {
+        THROW_ERROR("semop(P) failed (errno: %d)", errno);
+    }
+    // Verify value is 0 after P operation
+    sem_val = syscall(SYS_semctl, semid, 0, GETVAL);
+    if (sem_val != 0) {
+        INFO("P operation failed: expected val=0, actual=%d\n", sem_val);
+        return FAIL;
+    }
+
+    // Step 4: Create child process to perform V operation
+    // Initialize child process arguments (argv[0]=program name, argv[1]=test type, argv[2]=semid, argv[3]=initial value)
+    for (int i = 0; i < TEST_PROCESS_SYNC_ARGC; i++) {
+        child_argv[i] = (char *)malloc(ARG_BUF_SZ);
+        if (child_argv[i] == NULL) {
+            THROW_ERROR("malloc() failed for child argv");
+        }
+    }
+    snprintf(child_argv[0], ARG_BUF_SZ, "%s", prog_name);
+    snprintf(child_argv[1], ARG_BUF_SZ, "%d", TEST_PROCESS_SYNC);
+    snprintf(child_argv[2], ARG_BUF_SZ, "%d", semid);
+    snprintf(child_argv[3], ARG_BUF_SZ, "%d", SEM_INIT_VAL);
+    child_argv[TEST_PROCESS_SYNC_ARGC] = NULL;
+
+    // Execute child process V operation
+    if ((ret = execute_in_child(child_argv)) != SUCCESS) {
+        INFO("Child test (PROCESS_SYNC) failed\n");
+        return FAIL;
+    }
+
+    // Step 5: Verify semaphore value returns to 1 (child's V operation worked)
+    sem_val = syscall(SYS_semctl, semid, 0, GETVAL);
+    if (sem_val != 1) {
+        INFO("Sync failed: expected val=1, actual=%d\n", sem_val);
+        return FAIL;
+    }
+
+    // Cleanup resources
+    for (int i = 0; i < TEST_PROCESS_SYNC_ARGC; i++) {
+        free(child_argv[i]);
+    }
+
+    // Delete semaphore
+    ret = syscall(SYS_semctl, semid, 0, IPC_RMID);
+    if (ret < 0) {
+        THROW_ERROR("semctl(IPC_RMID) failed (errno: %d)", errno);
+    }
+
+    INFO("Test process_sync passed\n");
+    return SUCCESS;
+}
+
+/**
+ * Test 3: Verify immediate semaphore removal (abnormal scenario)
+ * Logic: Delete semaphore immediately after creation, subsequent stat operations return EINVAL
+ */
+static int test_immediately_rmsem(void) {
+    int ret, semid;
+    struct semid_ds sem_buf; // Semaphore status buffer
+
+    // Step 1: Create semaphore
+    semid = syscall(SYS_semget, IPC_PRIVATE, SEM_SET_SIZE, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (semid < 0) {
+        THROW_ERROR("semget() create failed (errno: %d)", errno);
+    }
+
+    // Step 2: Delete semaphore immediately
+    ret = syscall(SYS_semctl, semid, 0, IPC_RMID);
+    if (ret < 0) {
+        THROW_ERROR("semctl(IPC_RMID) failed (errno: %d)", errno);
+    }
+
+    // Step 3: Verify stat operation returns EINVAL after deletion (empty buffer)
+    ret = syscall(SYS_semctl, semid, 0, IPC_STAT, NULL);
+    if (ret != -1 || errno != EINVAL) {
+        INFO("semctl(IPC_STAT) failed: expected EINVAL, actual ret=%d, errno=%d\n", ret, errno);
+        return FAIL;
+    }
+
+    // Step 4: Verify stat operation returns EINVAL after deletion (non-empty buffer)
+    ret = syscall(SYS_semctl, semid, 0, IPC_STAT, &sem_buf);
+    if (ret != -1 || errno != EINVAL) {
+        INFO("semctl(IPC_STAT) failed: expected EINVAL, actual ret=%d, errno=%d\n", ret, errno);
+        return FAIL;
+    }
+
+    INFO("Test immediately_rmsem passed\n");
+    return SUCCESS;
+}
+
+/**
+ * Test 4: Operate on destroyed semaphore (abnormal scenario)
+ * Logic:
+ * 1. Parent creates semaphore then immediately deletes it
+ * 2. Child attempts to get by key → returns ENOENT
+ * 3. Child attempts to operate on deleted semid → returns EINVAL
+ */
+static int test_operate_destroyed_sem(void) {
+    int ret, semid;
+    key_t key;
+    char *child_argv[TEST_OPERATE_DESTOYED_ARGC + 1];
+
+    // Generate random key
+    srand(time(NULL));
+    key = random();
+    INFO("Test destroyed key: %d\n", key);
+
+    // Step 1: Create semaphore and set initial value
+    semid = syscall(SYS_semget, key, SEM_SET_SIZE, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (semid < 0) {
+        THROW_ERROR("semget() create failed (errno: %d)", errno);
+    }
+    ret = syscall(SYS_semctl, semid, 0, SETVAL, SEM_INIT_VAL);
+    if (ret < 0) {
+        THROW_ERROR("semctl(SETVAL) failed (errno: %d)", errno);
+    }
+
+    // Step 2: Delete semaphore immediately
+    ret = syscall(SYS_semctl, semid, 0, IPC_RMID);
+    if (ret < 0) {
+        THROW_ERROR("semctl(IPC_RMID) failed (errno: %d)", errno);
+    }
+
+    // Step 3: Child tests operations on destroyed semaphore
+    // Initialize child process arguments (argv[0]=program name, argv[1]=test type, argv[2]=key, argv[3]=semid, argv[4]=initial value)
+    for (int i = 0; i < TEST_OPERATE_DESTOYED_ARGC; i++) {
+        child_argv[i] = (char *)malloc(ARG_BUF_SZ);
+        if (child_argv[i] == NULL) {
+            THROW_ERROR("malloc() failed for child argv");
+        }
+    }
+    snprintf(child_argv[0], ARG_BUF_SZ, "%s", prog_name);
+    snprintf(child_argv[1], ARG_BUF_SZ, "%d", TEST_OPERATE_DESTOYED);
+    snprintf(child_argv[2], ARG_BUF_SZ, "%d", key);
+    snprintf(child_argv[3], ARG_BUF_SZ, "%d", semid);
+    snprintf(child_argv[4], ARG_BUF_SZ, "%d", SEM_INIT_VAL);
+    child_argv[TEST_OPERATE_DESTOYED_ARGC] = NULL;
+
+    // Execute child process test
+    if ((ret = execute_in_child(child_argv)) != SUCCESS) {
+        INFO("Child test (OPERATE_DESTROYED) failed\n");
+        return FAIL;
+    }
+
+    // Cleanup resources
+    for (int i = 0; i < TEST_OPERATE_DESTOYED_ARGC; i++) {
+        free(child_argv[i]);
+    }
+
+    INFO("Test operate_destroyed_sem passed\n");
+    return SUCCESS;
+}
+
+/**
+ * Test 5: Do not delete semaphore (memory leak detection)
+ * Note: As the last test case, verifies if LibOS reclaims unexplicitly deleted semaphore resources on exit
+ * Logic: Only create semaphore, do not perform IPC_RMID
+ */
+static int test_no_rmsem(void) {
+    int semid;
+
+    // Create semaphore and set initial value (do not delete)
+    semid = syscall(SYS_semget, IPC_PRIVATE, SEM_SET_SIZE, IPC_CREAT | IPC_EXCL | S_IRWUSER);
+    if (semid < 0) {
+        THROW_ERROR("semget() create failed (errno: %d)", errno);
+    }
+    int ret = syscall(SYS_semctl, semid, 0, SETVAL, SEM_INIT_VAL);
+    if (ret < 0) {
+        THROW_ERROR("semctl(SETVAL) failed (errno: %d)", errno);
+    }
+
+    INFO("Test no_rmsem passed (wait for resource recycle)\n");
+    return SUCCESS;
+}
+
+// ============================================================================
+// Child Process Test Logic (Corresponding to parent process test types)
+// ============================================================================
+
+/**
+ * Child process: Verify getting semid by key
+ */
+static int child_test_get_semid_by_key(int argc, const char *argv[]) {
+    key_t key;
+    int ret, semid, expected_semid, init_val;
+    int actual_val;
+
+    // Check parameter count
+    if (argc != TEST_GET_SEMID_BY_KEY_ARGC) {
+        INFO("Invalid argc: expected %d, actual %d\n", TEST_GET_SEMID_BY_KEY_ARGC, argc);
+        return FAIL;
+    }
+
+    // Parse parameters
+    key = atoi(argv[2]);
+    expected_semid = atoi(argv[3]);
+    init_val = atoi(argv[4]);
+    INFO("Child get key: %d, expected semid: %d\n", key, expected_semid);
+
+    // Get semid by key
+    semid = syscall(SYS_semget, key, SEM_SET_SIZE, S_IRWUSER);
+    if (semid < 0) {
+        THROW_ERROR("Child semget() failed (errno: %d)", errno);
+    }
+
+    // Verify semid matches parent's
+    if (semid != expected_semid) {
+        INFO("Child semid mismatch: expected %d, actual %d\n", expected_semid, semid);
+        return FAIL;
+    }
+
+    // Verify initial semaphore value is correct
+    actual_val = syscall(SYS_semctl, semid, 0, GETVAL);
+    if (actual_val != init_val) {
+        INFO("Child sem val mismatch: expected %d, actual %d\n", init_val, actual_val);
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+/**
+ * Child process: Perform V operation (synchronize with parent)
+ */
+static int child_test_process_sync(int argc, const char *argv[]) {
+    int semid, init_val;
+    int ret;
+    struct sembuf v_op = {0, 1, 0}; // V operation: sem_op=1
+
+    // Check parameter count
+    if (argc != TEST_PROCESS_SYNC_ARGC) {
+        INFO("Invalid argc: expected %d, actual %d\n", TEST_PROCESS_SYNC_ARGC, argc);
+        return FAIL;
+    }
+
+    // Parse parameters
+    semid = atoi(argv[2]);
+    init_val = atoi(argv[3]);
+    INFO("Child sync semid: %d, init val: %d\n", semid, init_val);
+
+    // Perform V operation (value from 0→1)
+    ret = syscall(SYS_semop, semid, &v_op, 1);
+    if (ret < 0) {
+        THROW_ERROR("Child semop(V) failed (errno: %d)", errno);
+    }
+
+    // Verify value is 1 after V operation
+    int sem_val = syscall(SYS_semctl, semid, 0, GETVAL);
+    if (sem_val != 1) {
+        INFO("Child V operation failed: expected val=1, actual=%d\n", sem_val);
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+/**
+ * Child process: Verify operations on destroyed semaphore
+ */
+static int child_test_operate_destroyed_sem(int argc, const char *argv[]) {
+    key_t key;
+    int semid, init_val;
+    int ret;
+    struct sembuf p_op = {0, -1, 0}; // Attempt P operation
+
+    // Check parameter count
+    if (argc != TEST_OPERATE_DESTOYED_ARGC) {
+        INFO("Invalid argc: expected %d, actual %d\n", TEST_OPERATE_DESTOYED_ARGC, argc);
+        return FAIL;
+    }
+
+    // Parse parameters
+    key = atoi(argv[2]);
+    semid = atoi(argv[3]);
+    init_val = atoi(argv[4]);
+    INFO("Child destroy test: key=%d, semid=%d\n", key, semid);
+
+    // Scenario 1: Get deleted semaphore by key → expect ENOENT
+    ret = syscall(SYS_semget, key, SEM_SET_SIZE, S_IRWUSER);
+    if (ret != -1 || errno != ENOENT) {
+        INFO("Child semget() failed: expected ENOENT, actual ret=%d, errno=%d\n", ret, errno);
+        return FAIL;
+    }
+
+    // Scenario 2: Operate on deleted semid → expect EINVAL
+    ret = syscall(SYS_semop, semid, &p_op, 1);
+    if (ret != -1 || errno != EINVAL) {
+        INFO("Child semop() failed: expected EINVAL, actual ret=%d, errno=%d\n", ret, errno);
+        return FAIL;
+    }
+
+    return SUCCESS;
+}
+
+// ============================================================================
+// Test Suite Entry
+// ============================================================================
+
+// Test case list (test_no_rmsem must be last for memory leak detection)
+static test_case_t test_cases[] = {
+    TEST_CASE(test_semget_semid_from_key),
+    TEST_CASE(test_process_sync),
+    TEST_CASE(test_immediately_rmsem),
+    TEST_CASE(test_operate_destroyed_sem),
+    TEST_CASE(test_no_rmsem),
+};
+
+int main(int argc, const char *argv[]) {
+    // Parent process: Run test suite
+    if (argc == 1) {
+        INFO("Start sem test suite (total cases: %d)\n", ARRAY_SIZE(test_cases));
+        return test_suite_run(test_cases, ARRAY_SIZE(test_cases));
+    }
+    // Child process: Execute specified test logic
+    else {
+        int option = atoi(argv[1]);
+        int ret = FAIL;
+
+        switch (option) {
+            case TEST_GET_SEMID_BY_KEY:
+                ret = child_test_get_semid_by_key(argc, argv);
+                break;
+            case TEST_PROCESS_SYNC:
+                ret = child_test_process_sync(argc, argv);
+                break;
+            case TEST_OPERATE_DESTOYED:
+                ret = child_test_operate_destroyed_sem(argc, argv);
+                break;
+            default:
+                INFO("Invalid test option: %d\n", option);
+                ret = FAIL;
+        }
+
+        // Child process returns 0 for success, -1 for failure
+        return (ret == SUCCESS) ? 0 : -1;
+    }
+}


### PR DESCRIPTION
Implemented core System V semaphore system calls: semget(), semop(), semtimedop(), semctl().

Implementation report and test report: [reports](https://github.com/OrangeQi-CQ/OSPP2025)
